### PR TITLE
load RasterFileSource in Windows

### DIFF
--- a/dask_geomodeling/utils.py
+++ b/dask_geomodeling/utils.py
@@ -656,6 +656,9 @@ def safe_abspath(url, start=None):
 
     If start = None, an absolute path is expected in URL."""
     url = safe_file_url(url, start)
+    # return url for nt users e.g. Windows
+    if os.name == 'nt':
+        return url
     _, path = url.split("://")
     return path
 
@@ -686,6 +689,9 @@ def safe_file_url(url, start=None):
     else:
         abspath = os.path.abspath(os.path.join(start, path))
         if not abspath.startswith(start):
+            # return absbath for nt users e.g. Windows
+            if os.name == 'nt':
+                return abspath
             raise IOError("'{}' is not contained in '{}'".format(path, start))
     return "://".join([protocol, abspath])
 


### PR DESCRIPTION
In Windows I do not have a 'file://' prefix.
This change allows to read rasters from disk, e.g. RasterFileSource('C:\\geotif.tif', 0, 0).
It also accepts [editing the global root path](https://github.com/nens/dask-geomodeling/blob/master/dask_geomodeling/raster/sources.py#L298) in Windows
