### PR TITLE
Fix empty response of TemporalAggregate and Cumulative

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of dask-geomodeling
 2.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix empty response of TemporalAggregate and Cumulative.
 
 
 2.1.0 (2019-11-15)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Changelog of dask-geomodeling
 
 - Fix empty response of TemporalAggregate and Cumulative.
 
+- Fix elementwise raster blocks in case of empty datasets.
+
 
 2.1.0 (2019-11-15)
 ------------------

--- a/dask_geomodeling/raster/elemwise.py
+++ b/dask_geomodeling/raster/elemwise.py
@@ -265,6 +265,10 @@ def wrap_math_process_func(func):
                     nodata_mask = _nodata_mask
                 else:
                     nodata_mask |= _nodata_mask
+            else:
+                raise TypeError(
+                    "Cannot apply math function to value {}".format(data)
+                )
 
         if dtype == np.dtype("bool"):
             no_data_value = None

--- a/dask_geomodeling/raster/elemwise.py
+++ b/dask_geomodeling/raster/elemwise.py
@@ -58,8 +58,9 @@ class BaseElementwise(RasterBlock):
         if start is not None and stop is not None:
             # limit request to self.period so that resulting data is aligned
             period = self.period
-            request["start"] = max(start, period[0])
-            request["stop"] = min(stop, period[1])
+            if period is not None:
+                request["start"] = max(start, period[0])
+                request["stop"] = min(stop, period[1])
 
         process_kwargs = {"dtype": self.dtype.name, "fillvalue": self.fillvalue}
         sources_and_requests = [(source, request) for source in self.args]

--- a/dask_geomodeling/raster/temporal.py
+++ b/dask_geomodeling/raster/temporal.py
@@ -509,7 +509,7 @@ class TemporalAggregate(BaseSingle):
 
         start, stop = self._snap_to_resampled_labels(start, stop)
         if start is None:
-            return [({"mode": "empty"}, None)]
+            return [({"empty": True, "mode": mode}, None)]
 
         # a time request does not involve a request to self.source
         if mode == "time":
@@ -557,7 +557,7 @@ class TemporalAggregate(BaseSingle):
     def process(process_kwargs, time_data=None, data=None):
         mode = process_kwargs["mode"]
         # handle empty data
-        if mode == "empty":
+        if process_kwargs.get("empty"):
             return None if mode == "vals" else {mode: []}
         start = process_kwargs["start"]
         stop = process_kwargs["stop"]
@@ -745,7 +745,7 @@ class Cumulative(BaseSingle):
         time_data = self.source.get_data(mode="time", start=start, stop=stop)
         if time_data is None or not time_data.get("time"):
             # return early for an empty source
-            return [({"mode": "empty"}, None)]
+            return [({"empty": True, "mode": mode}, None)]
 
         # get the periods from the first and last timestamp
         start = time_data["time"][0]
@@ -783,7 +783,7 @@ class Cumulative(BaseSingle):
     def process(process_kwargs, time_data=None, data=None):
         mode = process_kwargs["mode"]
         # handle empty data
-        if mode == "empty":
+        if process_kwargs.get("empty"):
             return None if mode == "vals" else {mode: []}
         if mode == "time":
             return time_data

--- a/dask_geomodeling/tests/test_raster.py
+++ b/dask_geomodeling/tests/test_raster.py
@@ -1107,6 +1107,11 @@ class TestTemporalAggregate(unittest.TestCase):
             "stop": Datetime(2020, 1, 1),
             **self.request,
         }
+        self.request_empty = {
+            "start": Datetime(1970, 1, 1),
+            "stop": Datetime(1971, 1, 1),
+            **self.request,
+        }
 
     def test_period_day_agg(self):
         self.assertEqual(
@@ -1376,6 +1381,20 @@ class TestTemporalAggregate(unittest.TestCase):
         result = view.get_data(**self.request_all)
         self.assertEqual(result["values"].dtype, np.int32)
 
+    def test_get_data_empty_vals(self):
+        view = self.klass(self.raster, "D")
+        assert view.get_data(**self.request_empty) is None
+
+    def test_get_data_empty_time(self):
+        view = self.klass(self.raster, "D")
+        self.request_empty["mode"] = "time"
+        assert view.get_data(**self.request_empty) == {"time": []}
+
+    def test_get_data_empty_meta(self):
+        view = self.klass(self.raster, "D")
+        self.request_empty["mode"] = "meta"
+        assert view.get_data(**self.request_empty) == {"meta": []}
+
 
 class TestCumulative(unittest.TestCase):
     klass = raster.Cumulative
@@ -1407,6 +1426,11 @@ class TestCumulative(unittest.TestCase):
         self.request_all = {
             "start": Datetime(1970, 1, 1),
             "stop": Datetime(2020, 1, 1),
+            **self.request,
+        }
+        self.request_empty = {
+            "start": Datetime(1970, 1, 1),
+            "stop": Datetime(1971, 1, 1),
             **self.request,
         }
 
@@ -1492,6 +1516,16 @@ class TestCumulative(unittest.TestCase):
         view = self.klass(self.raster, frequency="M", statistic="count")
         result = view.get_data(**self.request_all)
         assert_equal(result["values"], [[[1, 1, 0]], [[2, 2, 0]], [[3, 3, 0]]])
+
+    def test_get_data_empty_vals(self):
+        view = self.klass(self.raster, frequency="D", statistic="sum")
+        assert view.get_data(**self.request_empty) is None
+
+
+    def test_get_data_empty_meta(self):
+        view = self.klass(self.raster, frequency="D", statistic="sum")
+        self.request_empty["mode"] = "meta"
+        assert view.get_data(**self.request_empty) == {"meta": []}
 
 
 class TestBase(unittest.TestCase):


### PR DESCRIPTION
This fixes a bug where these two blocks returned `{"empty": []}` instead of `None` or `{"time": []}`

I also made the elemwise blocks a bit more clear in the error message

see https://nelen-schuurmans.atlassian.net/browse/BACK-606