### PR TITLE
Fix merge_files for shapefiles without tiling

### DIFF
--- a/dask_geomodeling/geometry/sinks.py
+++ b/dask_geomodeling/geometry/sinks.py
@@ -139,18 +139,21 @@ class GeometryFileSink(BaseSingle):
         if os.path.exists(target):
             raise IOError("Target '{}' already exists".format(target))
 
-        ext = os.path.splitext(target)[1]
+        target_base, ext = os.path.splitext(target)
         source_paths = glob.glob(os.path.join(path, '*' + ext))
         if len(source_paths) == 0:
             raise IOError(
                 "No source files found with matching extension '{}'".format(ext)
             )
         elif len(source_paths) == 1:
-            # shortcut for single file
-            if remove_source:
-                shutil.move(source_paths[0], target)
-            else:
-                shutil.copy(source_paths[0], target)
+            # shortcut for single file. we need to copy/move all base_name.*
+            # files (e.g. shapefiles have multiple files)
+            source_base = os.path.splitext(source_paths[0])[0]
+            move_or_copy = shutil.move if remove_source else shutil.copy
+            for file_path in glob.glob(source_base + '.*'):
+                move_or_copy(
+                    file_path, target_base + os.path.splitext(file_path)[1]
+                )
             return
 
         with utils.fiona_env():

--- a/dask_geomodeling/tests/test_geometry_sinks.py
+++ b/dask_geomodeling/tests/test_geometry_sinks.py
@@ -179,16 +179,31 @@ class TestGeometryFileSink(unittest.TestCase):
             assert len(df) == 1
             assert df.crs["init"] == "epsg:3857"
 
-    def test_to_file(self):
+    def test_to_file_geojson(self):
         self.source.to_file(self.path + ".geojson", **self.request)
         actual = gpd.read_file(self.path + ".geojson")
         # compare dataframes without checking the order of records / columns
         assert_frame_equal(actual, self.expected, check_like=True)
 
-    def test_to_file_with_tiling(self):
+    def test_to_file_shapefile(self):
+        self.source.to_file(self.path + ".shp", **self.request)
+        actual = gpd.read_file(self.path + ".shp")
+        # compare dataframes without checking the order of records / columns
+        assert_frame_equal(actual, self.expected, check_like=True)
+
+    def test_to_file_with_tiling_geojson(self):
         self.source.to_file(
             self.path + ".geojson", tile_size=10, **self.request_tiled
         )
         actual = gpd.read_file(self.path + ".geojson")
         # because we lose the index in the saving process, just check the len
         assert len(actual) == 2
+
+    def test_to_file_with_tiling_shapefile(self):
+        self.source.to_file(
+            self.path + ".shp", tile_size=10, **self.request_tiled
+        )
+        actual = gpd.read_file(self.path + ".shp")
+        # because we lose the index in the saving process, just check the len
+        assert len(actual) == 2
+


### PR DESCRIPTION
Shapefiles actually have multiple files, which should be accounted for in the copy or move action.