### PR TITLE
Rewrite raster documentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog of dask-geomodeling
 2.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Reworked the docstrings of all rasterblocks.
+
+- Renamed the 'location' parameter of raster.misc.Step to 'value'.
 
 
 2.2.1 (2020-02-04)

--- a/dask_geomodeling/raster/base.py
+++ b/dask_geomodeling/raster/base.py
@@ -1,5 +1,5 @@
 """
-Module containing the raster block base classes.
+Module containing the RasterBlock base classes.
 """
 from datetime import datetime as Datetime
 
@@ -9,7 +9,7 @@ from dask_geomodeling import Block
 class RasterBlock(Block):
     """ The base block for temporal rasters.
 
-    All raster blocks must be derived from this base class and must implement
+    All RasterBlocks must be derived from this base class and must implement
     the following attributes:
 
     - ``period``: a tuple of datetimes

--- a/dask_geomodeling/raster/combine.py
+++ b/dask_geomodeling/raster/combine.py
@@ -155,7 +155,7 @@ class Group(BaseCombine):
     shown (of rasters 'more to the left')
 
     Args:
-      a (list of rasters): list of rasters to be combined.
+      *args (list of rasters): list of rasters to be combined.
       
     Returns:
       Rasterblock which combines all input rasters

--- a/dask_geomodeling/raster/combine.py
+++ b/dask_geomodeling/raster/combine.py
@@ -147,17 +147,18 @@ class Group(BaseCombine):
     """
     Combine multiple rasters into a single one.
 
-    :param args: multiple RasterBlocks to be combined.
-    :type args: list of RasterBlock
+    Operation to combine multiple rasters into one along all three axes (x, y and temporal).
+    To only fill 'no data' values without temporal combination ``dask_geomodeling.raster.elemwise.FillNoData`` is preferred.
+    Values at equal timesteps in the contributing rasters are considered left to
+    right. Therefore values from rasters that are more 'to the right' are shown in the resulting raster. 
+    However, 'no data' values are transparent and in this case underlying data values are
+    shown (of rasters 'more to the left')
 
-    Values at equal timesteps in the contributing rasters are pasted left to
-    right. Therefore values from rasters that are more 'to the left' are
-    shadowed by values from rasters more 'to the right'. However, 'no data'
-    values are transparent and do not shadow underlying data values.
-
-    In the case of aligned equidistant time characteristics, the
-    procedure will use slicing in the processing of the result for
-    optimum performance.
+    Args:
+      a (list of rasters): list of rasters to be combined.
+      
+    Returns:
+      Rasterblack which combines all input rasters
     """
 
     def get_stores(self, start, stop):

--- a/dask_geomodeling/raster/combine.py
+++ b/dask_geomodeling/raster/combine.py
@@ -147,18 +147,21 @@ class Group(BaseCombine):
     """
     Combine multiple rasters into a single one.
 
-    Operation to combine multiple rasters into one along all three axes (x, y and temporal).
-    To only fill 'no data' values without temporal combination ``dask_geomodeling.raster.elemwise.FillNoData`` is preferred.
-    Values at equal timesteps in the contributing rasters are considered left to
-    right. Therefore values from rasters that are more 'to the right' are shown in the resulting raster. 
-    However, 'no data' values are transparent and in this case underlying data values are
-    shown (of rasters 'more to the left')
+    Operation to combine multiple rasters into one along all three axes (x, y
+    and temporal). To only fill 'no data' values of input rasters that have the
+    same temporal resolution ``dask_geomodeling.raster.elemwise.FillNoData``
+    is preferred.
+
+    Values at equal timesteps in the contributing rasters are considered
+    starting with the leftmost input raster. Therefore, values from rasters
+    that are more 'to the right' are shown in the result. 'no data' values are
+    transparent and will show data of rasters more 'to the left'.
 
     Args:
-      *args (list of rasters): list of rasters to be combined.
-      
+      *args (list of RasterBlocks): list of rasters to be combined.
+
     Returns:
-      Rasterblock which combines all input rasters
+      RasterBlock that combines all input rasters
     """
 
     def get_stores(self, start, stop):

--- a/dask_geomodeling/raster/combine.py
+++ b/dask_geomodeling/raster/combine.py
@@ -158,7 +158,7 @@ class Group(BaseCombine):
       a (list of rasters): list of rasters to be combined.
       
     Returns:
-      Rasterblack which combines all input rasters
+      Rasterblock which combines all input rasters
     """
 
     def get_stores(self, start, stop):

--- a/dask_geomodeling/raster/elemwise.py
+++ b/dask_geomodeling/raster/elemwise.py
@@ -645,7 +645,7 @@ class FillNoData(BaseElementwise):
     shown (of rasters 'more to the left')
 
     Args:
-      a (list of rasters): list of rasters to be combined.
+      *args (list of rasters): list of rasters to be combined.
       
     Returns:
       RasterBlock which shows input rasters from right to left, with 'no data' values being transparent

--- a/dask_geomodeling/raster/elemwise.py
+++ b/dask_geomodeling/raster/elemwise.py
@@ -293,16 +293,17 @@ def wrap_math_process_func(func):
 class Add(BaseMath):
     """
     Add two rasters together or add a constant value to a raster.
-    
-    Either one or both of the inputs should be a RasterBlock. In case of one raster input adds a constant value to this raster. In case of two raster inputs adds these rasters together. In this case the temporal properties of the rasters should be equal, however spatial properties may be different. 
-    
+
+    Either one or both of the inputs should be a RasterBlock. In case of
+    two raster inputs the temporal properties of the rasters should be equal,
+    however spatial properties can be different.
+
     Args:
-      a (RasterBlock, number): Addition parameter a
-      b (RasterBlock, number): Addition parameter b
+      a (RasterBlock, number): Addition term a
+      b (RasterBlock, number): Addition term b
 
     Returns:
-      RasterBlock containing the result of function *(a+b)*
-	  
+      RasterBlock containing the result of the addition.
 	"""
 
     process = staticmethod(wrap_math_process_func(np.add))
@@ -310,16 +311,18 @@ class Add(BaseMath):
 
 class Subtract(BaseMath):
     """
-    Subtract one raster from another or subtract a constant value from a raster.
-    
-    Either one or both of the inputs should be a rasterblock. In case of one raster input subtracts a constant value from this raster. In case of two raster inputs subtracts the second raster from the first raster. In this case the temporal properties of the rasters should be equal, however spatial properties may be different. 
-    
+    Subtract two rasters or subtract a constant value from a raster
+
+    Either one or both of the inputs should be a RasterBlock. In case of
+    two raster inputs the temporal properties of the rasters should be equal,
+    however spatial properties can be different.
+
     Args:
-      a (RasterBlock, number): Raster or value which gets subtracted from
-      b (RasterBlock, number): Raster or value which is subtracted
+      a (RasterBlock, number): Term be subtracted from
+      b (RasterBlock, number): Term to be subtracted
 
     Returns:
-      RasterBlock containing the result of function *(a-b)*
+      RasterBlock containing the result of the function subtract.
     """
 
     process = staticmethod(wrap_math_process_func(np.subtract))
@@ -327,13 +330,15 @@ class Subtract(BaseMath):
 
 class Multiply(BaseMath):
     """
-    Multiply the values of two rasters or multiply a raster by a constant value.
-    
-    Either one or both of the inputs should be a rasterblock. In case of one raster input multiplies this raster with a constant value. In case of two raster inputs multiplies the values of these two rasters. In this case the temporal properties of the rasters should be equal, however spatial properties may be different. 
+    Multiply two rasters or multiply a raster by a constant value.
+
+    Either one or both of the inputs should be a RasterBlock. In case of
+    two raster inputs the temporal properties of the rasters should be equal,
+    however spatial properties can be different.
 
     Args:
-      a (RasterBlock, number): Multiplication parameter a
-      b (RasterBlock, number): Multiplication parameter b
+      a (RasterBlock, number): Multiplication factor a
+      b (RasterBlock, number): Multiplication factor b
      
     Returns:
       RasterBlock containing the result of the multiplication.
@@ -344,13 +349,15 @@ class Multiply(BaseMath):
 
 class Divide(BaseMath):
     """
-    Divide one raster by another raster or divide a raster by a constant value.
+    Divide two rasters or divide a raster by a constant value.
 
-    Either one or both of the inputs should be a rasterblock. In case of one raster input divides this raster by a constant value. In case of two raster inputs divides the values of the first raster by the values of the second raster. In this case the temporal properties of the rasters should be equal, however spatial properties may be different. 
+    Either one or both of the inputs should be a RasterBlock. In case of
+    two raster inputs the temporal properties of the rasters should be equal,
+    however spatial properties can be different.
 
     Args:
-      a (RasterBlock, number): Fraction numerator
-      b (RasterBlock, number): Fraction denominator
+      a (RasterBlock, number): Numerator
+      b (RasterBlock, number): Denominator
      
     Returns:
       RasterBlock containing the result of the division.
@@ -366,13 +373,15 @@ class Divide(BaseMath):
 
 class Power(BaseMath):
     """
-    Exponential function, either with one raster and a constant value or two rasters. 
-    
-    Either one or both of the inputs should be a rasterblock. If both inputs are rasterblocks their temporal properties should be equal, however spatial properties may be different.
-    
+    Exponential function with either a raster and a number or two rasters.
+
+    Either one or both of the inputs should be a RasterBlock. In case of
+    two raster inputs the temporal properties of the rasters should be equal,
+    however spatial properties can be different.
+
     Args:
-      a (RasterBlock, number): Raster or value used as base
-      b (RasterBlock, number): Raster or value used as exponent
+      a (RasterBlock, number): Base
+      b (RasterBlock, number): Exponent
       
     Returns:
       RasterBlock containing the result of the exponential function. 
@@ -390,14 +399,19 @@ class Power(BaseMath):
 
 class Equal(BaseComparison):
     """
-    Compares the values of two rasters and returns True if they are equal. 
+    Compares the values of two rasters and returns True for equal elements.
 
-    This geoblock can be used to compare two rasters or to compare a raster with a static value. The resulting raster is boolean returning True if both inputs are the same value and False otherwise. 
-    Note that 'no data' is not equal to 'no data'. Either one or both of the inputs should be a rasterblock. If both inputs are rasterblocks their temporal properties should be equal, however spatial properties may be different.
+    This operation can be used to compare two rasters or to compare a raster
+    with a static value. Note that 'no data' is not equal to 'no data':
+    False is returned if any of the two terms is 'no data'.
+
+    Either one or both of the inputs should be a RasterBlock. In case of
+    two raster inputs the temporal properties of the rasters should be equal,
+    however spatial properties can be different.
 
     Args:
-      a (RasterBlock, number): Comparison parameter a
-      b (RasterBlock, number): Comparison parameter b
+      a (RasterBlock, number): Comparison term a
+      b (RasterBlock, number): Comparison term b
       
     Returns:
       RasterBlock containing boolean values
@@ -408,14 +422,19 @@ class Equal(BaseComparison):
 
 class NotEqual(BaseComparison):
     """
-    Compares the values of two rasters and returns False if they are equal.
+    Compares the values of two rasters and returns False for equal elements.
 
-    Opposite of ``dask_geomodeling.raster.elemwise.Equal``, this geoblock compares two rasters or a raster with a static value and returns False if they are equal, and true otherwise. 
-    Note that 'no data' is not equal to 'no data', and therefore returns True in this operation. Either one or both of the inputs should be a rasterblock. If both inputs are rasterblocks their temporal properties should be equal, however spatial properties may be different.
+    This operation can be used to compare two rasters or to compare a raster
+    with a static value. Note that 'no data' is not equal to 'no data':
+    True is returned if any of the two terms is 'no data'.
+
+    Either one or both of the inputs should be a RasterBlock. In case of
+    two raster inputs the temporal properties of the rasters should be equal,
+    however spatial properties can be different.
 
     Args:
-      a (RasterBlock, number): Comparison parameter a
-      b (RasterBlock, number): Comparison parameter b
+      a (RasterBlock, number): Comparison term a
+      b (RasterBlock, number): Comparison term b
 
     Returns:
       RasterBlock containing boolean values
@@ -426,14 +445,20 @@ class NotEqual(BaseComparison):
 
 class Greater(BaseComparison):
     """
-    Compares the values of two rasters and returns True if the first is higher than the second.
-    
-    This geoblock can be used to compare two rasters or to compare a raster with a static value. The resulting raster is boolean, returning True if the first input is a higher value than the second value. 
-    Herein 'no data' values will always return False. Either one or both of the inputs should be a rasterblock. If both inputs are rasterblocks their temporal properties should be equal, however spatial properties may be different.
-    
+    Compares the values of two rasters and returns True if an element in the
+    first term is greater.
+
+    This operation can be used to compare two rasters or to compare a raster
+    with a static value. Note that False is returned if any of the two terms is
+    'no data'.
+
+    Either one or both of the inputs should be a RasterBlock. In case of
+    two raster inputs the temporal properties of the rasters should be equal,
+    however spatial properties can be different.
+
     Args:
-      a (RasterBlock, number): Comparison parameter a
-      b (RasterBlock, number): Comparison parameter b
+      a (RasterBlock, number): Comparison term a
+      b (RasterBlock, number): Comparison term b
 
     Returns:
       RasterBlock containing boolean values
@@ -443,15 +468,21 @@ class Greater(BaseComparison):
 
 
 class GreaterEqual(BaseComparison):
-    """
-    Compares the values of two rasters and returns True if the first is higher than the second, or equal to the second.
-    
-    This geoblock can be used to compare two rasters or to compare a raster with a static value. The resulting raster is boolean, returning True if the first input is a higher value than the second value or equal to the second value. 
-    Herein 'no data' values will always return False. Either one or both of the inputs should be a rasterblock. If both inputs are rasterblocks their temporal properties should be equal, however spatial properties may be different.
+    """"
+    Compares the values of two rasters and returns True if an element in the
+    first term is greater or equal.
+
+    This operation can be used to compare two rasters or to compare a raster
+    with a static value. Note that False is returned if any of the two terms is
+    'no data'.
+
+    Either one or both of the inputs should be a RasterBlock. In case of
+    two raster inputs the temporal properties of the rasters should be equal,
+    however spatial properties can be different.
     
     Args:
-      a (RasterBlock, number): Comparison parameter a
-      b (RasterBlock, number): Comparison parameter b
+      a (RasterBlock, number): Comparison term a
+      b (RasterBlock, number): Comparison term b
 
     Returns:
       RasterBlock containing boolean values
@@ -462,14 +493,20 @@ class GreaterEqual(BaseComparison):
 
 class Less(BaseComparison):
     """
-    Compares the values of two rasters and returns True if the first is smaller than the second.
-    
-    This geoblock can be used to compare two rasters or to compare a raster with a static value. The resulting raster is boolean returning True if the first input is a lower value than the second value. 
-    Herein 'no data' values will always return False. Either one or both of the inputs should be a rasterblock. If both inputs are rasterblocks their temporal properties should be equal, however spatial properties may be different.
+    Compares the values of two rasters and returns True if an element in the
+    first term is less.
+
+    This operation can be used to compare two rasters or to compare a raster
+    with a static value. Note that False is returned if any of the two terms is
+    'no data'.
+
+    Either one or both of the inputs should be a RasterBlock. In case of
+    two raster inputs the temporal properties of the rasters should be equal,
+    however spatial properties can be different.
     
     Args:
-      a (RasterBlock, number): Comparison parameter a
-      b (RasterBlock, number): Comparison parameter b
+      a (RasterBlock, number): Comparison term a
+      b (RasterBlock, number): Comparison term b
 
     Returns:
       RasterBlock containing boolean values
@@ -480,14 +517,20 @@ class Less(BaseComparison):
 
 class LessEqual(BaseComparison):
     """
-    Compares the values of two rasters and returns True if the first is lower than the second, or equal to the second.
-    
-    This geoblock can be used to compare two rasters or to compare a raster with a static value. The resulting raster is boolean, returning True if the first input is a lower value than the second value or equal to the second value. 
-    Herein 'no data' values will always return False. Either one or both of the inputs should be a rasterblock. If both inputs are rasterblocks their temporal properties should be equal, however spatial properties may be different.
+    Compares the values of two rasters and returns True if an element in the
+    first term is less or equal.
+
+    This operation can be used to compare two rasters or to compare a raster
+    with a static value. Note that False is returned if any of the two terms is
+    'no data'.
+
+    Either one or both of the inputs should be a RasterBlock. In case of
+    two raster inputs the temporal properties of the rasters should be equal,
+    however spatial properties can be different.
     
     Args:
-      a (RasterBlock, number): Comparison parameter a
-      b (RasterBlock, number): Comparison parameter b
+      a (RasterBlock, number): Comparison term a
+      b (RasterBlock, number): Comparison term b
 
     Returns:
       RasterBlock containing boolean values
@@ -498,9 +541,10 @@ class LessEqual(BaseComparison):
 
 class Invert(BaseSingle):
     """
-    Taken a raster with boolean values and swaps True and False.
+    Logically invert a raster (swap True and False).
     
-    Takes a single input raster containing boolean values. Outputs a boolean raster with the same spatial and temportal properties.
+    Takes a single input raster containing boolean values and outputs a boolean
+    raster with the same spatial and temportal properties.
 
     Args:
       x (RasterBlock): Boolean raster with values to invert
@@ -530,10 +574,11 @@ class IsData(BaseSingle):
     """
     Returns True where raster has data.
     
-    Takes a single input raster. Outputs a boolean raster with the same spatial and temportal properties, for cells where the input raster has data returns True, and False otherwise. 
+    Takes a single input raster and outputs a boolean raster with the same
+    spatial and temporal properties.
 
     Args:
-      store (RasterBlock): Single input raster
+      store (RasterBlock): Input raster
 
     Returns:
       RasterBlock with boolean values. 
@@ -564,11 +609,12 @@ class IsData(BaseSingle):
 class IsNoData(IsData):
     """
     Returns True where raster has no data.
-    
-    Opposite of ``dask_geomodeling.raster.elemwise.IsData``, also takes a single input raster. But outputs False for cells with data in the input raster, and True otherwise.
+
+    Takes a single input raster and outputs a boolean raster with the same
+    spatial and temporal properties.
 
     Args:
-      store (RasterBlock): Single input raster
+      store (RasterBlock): Input raster
 
     Returns:
       RasterBlock with boolean values. 
@@ -585,14 +631,15 @@ class IsNoData(IsData):
 
 class And(BaseLogic):
     """
-    Taken two boolean input rasters and returns True when both are True. 
+    Returns True where both inputs are True.
 
-    Takes two boolean rasters or a boolean raster and a single boolean value. The resulting raster returns a True value if both inputs are True.
-    If both inputs are rasterblocks their temporal properties should be equal, however spatial properties may be different.
+    Either one or both of the inputs should be a boolean RasterBlock. In case
+    of two raster inputs the temporal properties of the rasters should be
+    equal, however spatial properties can be different.
     
     Args:
-      a (RasterBlock, boolean): Boolean input a
-      b (RasterBlock, boolean): Boolean input b
+      a (RasterBlock, boolean): Logical term a
+      b (RasterBlock, boolean): Logical term b
 
     Returns:
       RasterBlock containing boolean values
@@ -603,14 +650,15 @@ class And(BaseLogic):
 
 class Or(BaseLogic):
     """
-    Taken two boolean input rasters and returns True when either or both are True. 
+    Returns True where any of inputs is True.
 
-    Takes two boolean rasters or a boolean raster and a single boolean value. The resulting raster returns a True value if either if the inputs is True, or if both of the inputs are True. 
-    If both inputs are rasterblocks their temporal properties should be equal, however spatial properties may be different.
-    
+    Either one or both of the inputs should be a boolean RasterBlock. In case
+    of two raster inputs the temporal properties of the rasters should be
+    equal, however spatial properties can be different.
+
     Args:
-      a (RasterBlock, boolean): Boolean input a
-      b (RasterBlock, boolean): Boolean input b
+      a (RasterBlock, boolean): Logical term a
+      b (RasterBlock, boolean): Logical term b
 
     Returns:
       RasterBlock containing boolean values
@@ -621,14 +669,17 @@ class Or(BaseLogic):
 
 class Xor(BaseLogic):
     """
-    Takes two boolean input rasters and returns True when either is True, but False if both are True. 
+    Exclusive or: returns True where exactly one of the inputs is True.
 
-    Takes two boolean rasters or a boolean raster and a single boolean value. The resulting raster returns True value if either if the inputs is True, but False if both are True. Also returns False when both inputs are False. 
-    If both inputs are rasterblocks their temporal properties should be equal, however spatial properties may be different.
-    
+    Where both inputs are True, False is returned.
+
+    Either one or both of the inputs should be a boolean RasterBlock. In case
+    of two raster inputs the temporal properties of the rasters should be
+    equal, however spatial properties can be different.
+
     Args:
-      a (RasterBlock, boolean): Boolean input a
-      b (RasterBlock, boolean): Boolean input b
+      a (RasterBlock, boolean): Logical term a
+      b (RasterBlock, boolean): Logical term b
 
     Returns:
       RasterBlock containing boolean values
@@ -639,18 +690,21 @@ class Xor(BaseLogic):
 
 class FillNoData(BaseElementwise):
     """
-    Combines multiple rasters, filling in 'no data' values.
+    Combines multiple rasters filling 'no data' values.
 
-    Values in the contributing rasters are considered left to
-    right. Therefore values from rasters that are more 'to the right' are shown in the resulting raster. 
-    However, 'no data' values are transparent and in this case underlying data values are
-    shown (of rasters 'more to the left')
+    Values at equal timesteps in the contributing rasters are considered
+    starting with the leftmost input raster. Therefore, values from rasters
+    that are more 'to the right' are shown in the result. 'no data' values are
+    transparent and will show data of rasters more 'to the left'.
+
+    The temporal properties of the rasters should be equal, however spatial
+    properties can be different.
 
     Args:
-      *args (list of rasters): list of rasters to be combined.
+      *args (list of RasterBlocks): Rasters to be combined.
       
     Returns:
-      RasterBlock which shows input rasters from right to left, with 'no data' values being transparent
+      RasterBlock that combines values from the inputs.
     """
 
     def __init__(self, *args):

--- a/dask_geomodeling/raster/elemwise.py
+++ b/dask_geomodeling/raster/elemwise.py
@@ -304,6 +304,7 @@ class Add(BaseMath):
       RasterBlock containing the result of function *(a+b)*
 	  
 	"""
+
     process = staticmethod(wrap_math_process_func(np.add))
 
 
@@ -473,6 +474,7 @@ class Less(BaseComparison):
     Returns:
       RasterBlock containing boolean values
     """
+
     process = staticmethod(wrap_math_process_func(np.less))
 
 

--- a/dask_geomodeling/raster/elemwise.py
+++ b/dask_geomodeling/raster/elemwise.py
@@ -292,25 +292,27 @@ def wrap_math_process_func(func):
 
 class Add(BaseMath):
     """
-    Add a value.
+    Add two rasters together or add a constant value to a raster.
+    
+    Either one or both of the inputs should be a rasterblock. In case of one raster input adds a constant value to this raster. In case of two raster inputs adds these rasters together. In this case spatial and temporal properties of the rasters should be equal. 
+    
+    Args:
+      a (Rasterblock, number): Addition parameter a
+      b (Rasterblock, number): Addition parameter b
 
-    :param a: Addition parameter a
-    :param b: Addition parameter b
-
-    :type a: RasterBlock, scalar
-    :type b: RasterBlock, scalar
-
-    At least one of the parameters should be a RasterBlock. If the
-    params are both RasterBlocks, they should share exactly the
-    same time structure. The Snap block can be used to accomplish this.
-    """
+    Returns:
+      Single raster that contains added values
+    
+	See also:
+	  :class:`dask_geomodeling.raster.elemwise.Subtract`
+	"""
 
     process = staticmethod(wrap_math_process_func(np.add))
 
 
 class Subtract(BaseMath):
     """
-    Subtract a constant value from a store or vice versa.
+    Subtract a constant value from a raster or subtract 
 
     :param a: Subtraction parameter a
     :param b: Subtraction parameter b

--- a/dask_geomodeling/raster/elemwise.py
+++ b/dask_geomodeling/raster/elemwise.py
@@ -294,35 +294,31 @@ class Add(BaseMath):
     """
     Add two rasters together or add a constant value to a raster.
     
-    Either one or both of the inputs should be a rasterblock. In case of one raster input adds a constant value to this raster. In case of two raster inputs adds these rasters together. In this case spatial and temporal properties of the rasters should be equal. 
+    Either one or both of the inputs should be a rasterblock. In case of one raster input adds a constant value to this raster. In case of two raster inputs adds these rasters together. In this case the temporal properties of the rasters should be equal, however spatial properties may be different. 
     
     Args:
-      a (Rasterblock, number): Addition parameter a
-      b (Rasterblock, number): Addition parameter b
+      a (RasterBlock, number): Addition parameter a
+      b (RasterBlock, number): Addition parameter b
 
     Returns:
-      Single raster that contains added values
-    
-	See also:
-	  :class:`dask_geomodeling.raster.elemwise.Subtract`
+      Rasterblock containing the result of function *(a+b)*
+	  
 	"""
-
     process = staticmethod(wrap_math_process_func(np.add))
 
 
 class Subtract(BaseMath):
     """
-    Subtract a constant value from a raster or subtract 
+    Subtract one raster from another or subtract a constant value from a raster.
+    
+    Either one or both of the inputs should be a rasterblock. In case of one raster input subtracts a constant value from this raster. In case of two raster inputs subtracts the second raster from the first raster. In this case the temporal properties of the rasters should be equal, however spatial properties may be different. 
+    
+    Args:
+      a (RasterBlock, number): Raster or value which gets subtracted from
+      b (RasterBlock, number): Raster or value which is subtracted
 
-    :param a: Subtraction parameter a
-    :param b: Subtraction parameter b
-
-    :type a: RasterBlock, scalar
-    :type b: RasterBlock, scalar
-
-    At least one of the parameters should be a RasterBlock. If the
-    params are both RasterBlocks, they should share exactly the
-    same time structure. The Snap block can be used to accomplish this.
+    Returns:
+      Rasterblock containing the result of function *(a-b)*
     """
 
     process = staticmethod(wrap_math_process_func(np.subtract))
@@ -330,17 +326,16 @@ class Subtract(BaseMath):
 
 class Multiply(BaseMath):
     """
-    Multiply by a value.
+    Multiply the values of two rasters or multiply a raster by a constant value.
+    
+    Either one or both of the inputs should be a rasterblock. In case of one raster input multiplies this raster with a constant value. In case of two raster inputs multiplies the values of these two rasters. In this case the temporal properties of the rasters should be equal, however spatial properties may be different. 
 
-    :param a: Multiplication parameter a
-    :param b: Multiplication parameter b
-
-    :type a: RasterBlock, scalar
-    :type b: RasterBlock, scalar
-
-    At least one of the parameters should be a RasterBlock. If the
-    params are both RasterBlocks, they should share exactly the
-    same time structure. The Snap block can be used to accomplish this.
+    Args:
+      a (RasterBlock, number): Multiplication parameter a
+      b (RasterBlock, number): Multiplication parameter b
+     
+    Returns:
+      Rasterblock containing the result of the multiplication.
     """
 
     process = staticmethod(wrap_math_process_func(np.multiply))
@@ -348,17 +343,16 @@ class Multiply(BaseMath):
 
 class Divide(BaseMath):
     """
-    Divide Store by a constant value or vice versa.
+    Divide one raster by another raster or divide a raster by a constant value.
 
-    :param a: Division parameter a
-    :param b: Division parameter b
+    Either one or both of the inputs should be a rasterblock. In case of one raster input divides this raster by a constant value. In case of two raster inputs divides the values of the first raster by the values of the second raster. In this case the temporal properties of the rasters should be equal, however spatial properties may be different. 
 
-    :type a: RasterBlock, scalar
-    :type b: RasterBlock, scalar
-
-    At least one of the parameters should be a RasterBlock. If the
-    params are both RasterBlocks, they should share exactly the
-    same time structure. The Snap block can be used to accomplish this.
+    Args:
+      a (RasterBlock, number): Raster or value which is divided from
+      b (RasterBlock, number): Raster or value which is divided by
+     
+    Returns:
+      Rasterblock containing the result of the division.
     """
 
     process = staticmethod(wrap_math_process_func(np.divide))
@@ -371,17 +365,16 @@ class Divide(BaseMath):
 
 class Power(BaseMath):
     """
-    Raise each number in a to the power b.
-
-    :param a: base
-    :param b: exponent
-
-    :type a: RasterBlock, scalar
-    :type b: RasterBlock, scalar
-
-    At least one of the parameters should be a RasterBlock. If the
-    params are both RasterBlocks, they should share exactly the
-    same time structure. The Snap block can be used to accomplish this.
+    Exponential function, either with one raster and a constant value or two rasters. 
+    
+    Either one or both of the inputs should be a rasterblock. If both inputs are rasterblocks their temporal properties should be equal, however spatial properties may be different.
+    
+    Args:
+      a (RasterBlock, number): Raster or value used as base
+      b (RasterBlock, number): Raster or value used as exponent
+      
+    Returns:
+      Rasterblock containing the result of the exponential function. 
     """
 
     process = staticmethod(wrap_math_process_func(np.power))
@@ -396,19 +389,17 @@ class Power(BaseMath):
 
 class Equal(BaseComparison):
     """
-    Compares the values of two stores and returns True if they are equal.
+    Compares the values of two rasters and returns True if they are equal. 
 
-    Note that "no data" is not equal to "no data".
+    This geoblock can be used to compare two rasters or to compare a raster with a static value. The resulting raster is boolean returning True if both inputs are the same value and False otherwise. 
+    Note that 'no data' is not equal to 'no data'. Either one or both of the inputs should be a rasterblock. If both inputs are rasterblocks their temporal properties should be equal, however spatial properties may be different.
 
-    :param a: Comparison parameter a
-    :param b: Comparison parameter b
-
-    :type a: RasterBlock, scalar
-    :type b: RasterBlock, scalar
-
-    At least one of the parameters should be a RasterBlock. If the
-    params are both RasterBlocks, they should share exactly the
-    same time structure. The Snap block can be used to accomplish this.
+    Args:
+      a (RasterBlock, number): Comparison parameter a
+      b (RasterBlock, number): Comparison parameter b
+      
+    Returns:
+      Rasterblock containing boolean values
     """
 
     process = staticmethod(wrap_math_process_func(np.equal))
@@ -416,19 +407,17 @@ class Equal(BaseComparison):
 
 class NotEqual(BaseComparison):
     """
-    Compares the values of two stores and returns False if they are equal.
+    Compares the values of two rasters and returns False if they are equal.
 
-    Note that "no data" is not equal to "no data".
+    Opposite of ``dask_geomodeling.raster.elemwise.Equal``, this geoblock compares two rasters or a raster with a static value and returns False if they are equal, and true otherwise. 
+    Note that 'no data' is not equal to 'no data', and therefore returns True in this operation. Either one or both of the inputs should be a rasterblock. If both inputs are rasterblocks their temporal properties should be equal, however spatial properties may be different.
 
-    :param a: Comparison parameter a
-    :param b: Comparison parameter b
+    Args:
+      a (RasterBlock, number): Comparison parameter a
+      b (RasterBlock, number): Comparison parameter b
 
-    :type a: RasterBlock, scalar
-    :type b: RasterBlock, scalar
-
-    At least one of the parameters should be a RasterBlock. If the
-    params are both RasterBlocks, they should share exactly the
-    same time structure. The Snap block can be used to accomplish this.
+    Returns:
+      Rasterblock containing boolean values
     """
 
     process = staticmethod(wrap_math_process_func(np.not_equal))
@@ -436,19 +425,17 @@ class NotEqual(BaseComparison):
 
 class Greater(BaseComparison):
     """
-    Returns True if a is greater than b.
+    Compares the values of two rasters and returns True if the first is higher than the second.
+    
+    This geoblock can be used to compare two rasters or to compare a raster with a static value. The resulting raster is boolean, returning True if the first input is a higher value than the second value. 
+    Herein 'no data' values will always return False. Either one or both of the inputs should be a rasterblock. If both inputs are rasterblocks their temporal properties should be equal, however spatial properties may be different.
+    
+    Args:
+      a (RasterBlock, number): Comparison parameter a
+      b (RasterBlock, number): Comparison parameter b
 
-    Note that "no data" will always return False
-
-    :param a: Comparison parameter a
-    :param b: Comparison parameter b
-
-    :type a: RasterBlock, scalar
-    :type b: RasterBlock, scalar
-
-    At least one of the parameters should be a RasterBlock. If the
-    params are both RasterBlocks, they should share exactly the
-    same time structure. The Snap block can be used to accomplish this.
+    Returns:
+      Rasterblock containing boolean values
     """
 
     process = staticmethod(wrap_math_process_func(np.greater))
@@ -456,19 +443,17 @@ class Greater(BaseComparison):
 
 class GreaterEqual(BaseComparison):
     """
-    Returns True if a is greater than or equal to b.
+    Compares the values of two rasters and returns True if the first is higher than the second, or equal to the second.
+    
+    This geoblock can be used to compare two rasters or to compare a raster with a static value. The resulting raster is boolean, returning True if the first input is a higher value than the second value or equal to the second value. 
+    Herein 'no data' values will always return False. Either one or both of the inputs should be a rasterblock. If both inputs are rasterblocks their temporal properties should be equal, however spatial properties may be different.
+    
+    Args:
+      a (RasterBlock, number): Comparison parameter a
+      b (RasterBlock, number): Comparison parameter b
 
-    Note that "no data" will always return False
-
-    :param a: Comparison parameter a
-    :param b: Comparison parameter b
-
-    :type a: RasterBlock, scalar
-    :type b: RasterBlock, scalar
-
-    At least one of the parameters should be a RasterBlock. If the
-    params are both RasterBlocks, they should share exactly the
-    same time structure. The Snap block can be used to accomplish this.
+    Returns:
+      Rasterblock containing boolean values
     """
 
     process = staticmethod(wrap_math_process_func(np.greater_equal))
@@ -476,39 +461,34 @@ class GreaterEqual(BaseComparison):
 
 class Less(BaseComparison):
     """
-    Returns True if a is less than b.
+    Compares the values of two rasters and returns True if the first is smaller than the second.
+    
+    This geoblock can be used to compare two rasters or to compare a raster with a static value. The resulting raster is boolean returning True if the first input is a lower value than the second value. 
+    Herein 'no data' values will always return False. Either one or both of the inputs should be a rasterblock. If both inputs are rasterblocks their temporal properties should be equal, however spatial properties may be different.
+    
+    Args:
+      a (RasterBlock, number): Comparison parameter a
+      b (RasterBlock, number): Comparison parameter b
 
-    Note that "no data" will always return False
-
-    :param a: Comparison parameter a
-    :param b: Comparison parameter b
-
-    :type a: RasterBlock, scalar
-    :type b: RasterBlock, scalar
-
-    At least one of the parameters should be a RasterBlock. If the
-    params are both RasterBlocks, they should share exactly the
-    same time structure. The Snap block can be used to accomplish this.
+    Returns:
+      Rasterblock containing boolean values
     """
-
     process = staticmethod(wrap_math_process_func(np.less))
 
 
 class LessEqual(BaseComparison):
     """
-    Returns True if a is less than or equal to b.
+    Compares the values of two rasters and returns True if the first is lower than the second, or equal to the second.
+    
+    This geoblock can be used to compare two rasters or to compare a raster with a static value. The resulting raster is boolean, returning True if the first input is a lower value than the second value or equal to the second value. 
+    Herein 'no data' values will always return False. Either one or both of the inputs should be a rasterblock. If both inputs are rasterblocks their temporal properties should be equal, however spatial properties may be different.
+    
+    Args:
+      a (RasterBlock, number): Comparison parameter a
+      b (RasterBlock, number): Comparison parameter b
 
-    Note that "no data" will always return False
-
-    :param a: Comparison parameter a
-    :param b: Comparison parameter b
-
-    :type a: RasterBlock, scalar
-    :type b: RasterBlock, scalar
-
-    At least one of the parameters should be a RasterBlock. If the
-    params are both RasterBlocks, they should share exactly the
-    same time structure. The Snap block can be used to accomplish this.
+    Returns:
+      Rasterblock containing boolean values
     """
 
     process = staticmethod(wrap_math_process_func(np.less_equal))
@@ -516,10 +496,15 @@ class LessEqual(BaseComparison):
 
 class Invert(BaseSingle):
     """
-    Swaps False and True ("not x" or "~x").
+    Taken a raster with boolean values and swaps True and False.
+    
+    Takes a single input raster containing boolean values. Outputs a boolean raster with the same spatial and temportal properties.
 
-    :param x: raster data to invert
-    :type x: RasterBlock
+    Args:
+      x (RasterBlock): Boolean raster with values to invert
+
+    Returns:
+      Rasterblock with boolean values opposite to the input raster. 
     """
 
     def __init__(self, x):
@@ -540,10 +525,16 @@ class Invert(BaseSingle):
 
 
 class IsData(BaseSingle):
-    """Returns True where raster has data.
+    """
+    Returns True where raster has data.
+    
+    Takes a single input raster. Outputs a boolean raster with the same spatial and temportal properties, for cells where the input raster has data returns True, and False otherwise. 
 
-    :param store:
-    :type store: RasterBlock
+    Args:
+      store (RasterBlock): Single input raster
+
+    Returns:
+      Rasterblock with boolean values. 
     """
 
     def __init__(self, store):
@@ -569,10 +560,16 @@ class IsData(BaseSingle):
 
 
 class IsNoData(IsData):
-    """Returns True where raster has no data.
+    """
+    Returns True where raster has no data.
+    
+    Opposite of ``dask_geomodeling.raster.elemwise.IsData``, also takes a single input raster. But outputs False for cells with data in the input raster, and True otherwise.
 
-    :param store:
-    :type store: RasterBlock
+    Args:
+      store (RasterBlock): Single input raster
+
+    Returns:
+      Rasterblock with boolean values. 
     """
 
     @staticmethod
@@ -586,18 +583,17 @@ class IsNoData(IsData):
 
 class And(BaseLogic):
     """
-    Returns True where a and b are True.
+    Taken two boolean input rasters and returns True when both are True. 
 
-    :param a: Comparison parameter a
-    :param b: Comparison parameter b
+    Takes two boolean rasters or a boolean raster and a single boolean value. The resulting raster returns a True value if both inputs are True.
+    If both inputs are rasterblocks their temporal properties should be equal, however spatial properties may be different.
+    
+    Args:
+      a (RasterBlock, boolean): Boolean input a
+      b (RasterBlock, boolean): Boolean input b
 
-    :type a: RasterBlock, boolean
-    :type b: RasterBlock, boolean
-
-    All input parameters should have a boolean dtype and at least one of the
-    parameters should be a RasterBlock. If both are RasterBlocks, they should
-    share exactly the same time structure. The Snap block can be used to
-    accomplish this.
+    Returns:
+      Rasterblock containing boolean values
     """
 
     process = staticmethod(wrap_math_process_func(np.logical_and))
@@ -605,18 +601,17 @@ class And(BaseLogic):
 
 class Or(BaseLogic):
     """
-    Returns True where a or b are True.
+    Taken two boolean input rasters and returns True when either or both are True. 
 
-    :param a: Comparison parameter a
-    :param b: Comparison parameter b
+    Takes two boolean rasters or a boolean raster and a single boolean value. The resulting raster returns a True value if either if the inputs is True, or if both of the inputs are True. 
+    If both inputs are rasterblocks their temporal properties should be equal, however spatial properties may be different.
+    
+    Args:
+      a (RasterBlock, boolean): Boolean input a
+      b (RasterBlock, boolean): Boolean input b
 
-    :type a: RasterBlock, boolean
-    :type b: RasterBlock, boolean
-
-    All input parameters should have a boolean dtype and at least one of the
-    parameters should be a RasterBlock. If both are RasterBlocks, they should
-    share exactly the same time structure. The Snap block can be used to
-    accomplish this.
+    Returns:
+      Rasterblock containing boolean values
     """
 
     process = staticmethod(wrap_math_process_func(np.logical_or))
@@ -624,18 +619,17 @@ class Or(BaseLogic):
 
 class Xor(BaseLogic):
     """
-    Returns True where either a or b is True (exclusive-or)
+    Takes two boolean input rasters and returns True when either is True, but False if both are True. 
 
-    :param a: Comparison parameter a
-    :param b: Comparison parameter b
+    Takes two boolean rasters or a boolean raster and a single boolean value. The resulting raster returns True value if either if the inputs is True, but False if both are True. Also returns False when both inputs are False. 
+    If both inputs are rasterblocks their temporal properties should be equal, however spatial properties may be different.
+    
+    Args:
+      a (RasterBlock, boolean): Boolean input a
+      b (RasterBlock, boolean): Boolean input b
 
-    :type a: RasterBlock, boolean
-    :type b: RasterBlock, boolean
-
-    All input parameters should have a boolean dtype and at least one of the
-    parameters should be a RasterBlock. If both are RasterBlocks, they should
-    share exactly the same time structure. The Snap block can be used to
-    accomplish this.
+    Returns:
+      Rasterblock containing boolean values
     """
 
     process = staticmethod(wrap_math_process_func(np.logical_xor))
@@ -643,15 +637,18 @@ class Xor(BaseLogic):
 
 class FillNoData(BaseElementwise):
     """
-    Combines multiple rasters, filling in nodata values.
+    Combines multiple rasters, filling in 'no data' values.
 
-    :param args: list of raster sources to be combined.
-    :type args: list of RasterBlock
+    Values in the contributing rasters are considered left to
+    right. Therefore values from rasters that are more 'to the right' are shown in the resulting raster. 
+    However, 'no data' values are transparent and in this case underlying data values are
+    shown (of rasters 'more to the left')
 
-    Values at equal timesteps in the contributing rasters are pasted left to
-    right. Therefore values from rasters that are more 'to the left' are
-    shadowed by values from rasters more 'to the right'. However, 'no data'
-    values are transparent and do not shadow underlying data values.
+    Args:
+      a (list of rasters): list of rasters to be combined.
+      
+    Returns:
+      Rasterblock which shows input rasters from right to left, with 'no data' values being transparent
     """
 
     def __init__(self, *args):

--- a/dask_geomodeling/raster/elemwise.py
+++ b/dask_geomodeling/raster/elemwise.py
@@ -294,14 +294,14 @@ class Add(BaseMath):
     """
     Add two rasters together or add a constant value to a raster.
     
-    Either one or both of the inputs should be a rasterblock. In case of one raster input adds a constant value to this raster. In case of two raster inputs adds these rasters together. In this case the temporal properties of the rasters should be equal, however spatial properties may be different. 
+    Either one or both of the inputs should be a RasterBlock. In case of one raster input adds a constant value to this raster. In case of two raster inputs adds these rasters together. In this case the temporal properties of the rasters should be equal, however spatial properties may be different. 
     
     Args:
       a (RasterBlock, number): Addition parameter a
       b (RasterBlock, number): Addition parameter b
 
     Returns:
-      Rasterblock containing the result of function *(a+b)*
+      RasterBlock containing the result of function *(a+b)*
 	  
 	"""
     process = staticmethod(wrap_math_process_func(np.add))
@@ -318,7 +318,7 @@ class Subtract(BaseMath):
       b (RasterBlock, number): Raster or value which is subtracted
 
     Returns:
-      Rasterblock containing the result of function *(a-b)*
+      RasterBlock containing the result of function *(a-b)*
     """
 
     process = staticmethod(wrap_math_process_func(np.subtract))
@@ -335,7 +335,7 @@ class Multiply(BaseMath):
       b (RasterBlock, number): Multiplication parameter b
      
     Returns:
-      Rasterblock containing the result of the multiplication.
+      RasterBlock containing the result of the multiplication.
     """
 
     process = staticmethod(wrap_math_process_func(np.multiply))
@@ -348,11 +348,11 @@ class Divide(BaseMath):
     Either one or both of the inputs should be a rasterblock. In case of one raster input divides this raster by a constant value. In case of two raster inputs divides the values of the first raster by the values of the second raster. In this case the temporal properties of the rasters should be equal, however spatial properties may be different. 
 
     Args:
-      a (RasterBlock, number): Raster or value which is divided from
-      b (RasterBlock, number): Raster or value which is divided by
+      a (RasterBlock, number): Fraction numerator
+      b (RasterBlock, number): Fraction denominator
      
     Returns:
-      Rasterblock containing the result of the division.
+      RasterBlock containing the result of the division.
     """
 
     process = staticmethod(wrap_math_process_func(np.divide))
@@ -374,7 +374,7 @@ class Power(BaseMath):
       b (RasterBlock, number): Raster or value used as exponent
       
     Returns:
-      Rasterblock containing the result of the exponential function. 
+      RasterBlock containing the result of the exponential function. 
     """
 
     process = staticmethod(wrap_math_process_func(np.power))
@@ -399,7 +399,7 @@ class Equal(BaseComparison):
       b (RasterBlock, number): Comparison parameter b
       
     Returns:
-      Rasterblock containing boolean values
+      RasterBlock containing boolean values
     """
 
     process = staticmethod(wrap_math_process_func(np.equal))
@@ -417,7 +417,7 @@ class NotEqual(BaseComparison):
       b (RasterBlock, number): Comparison parameter b
 
     Returns:
-      Rasterblock containing boolean values
+      RasterBlock containing boolean values
     """
 
     process = staticmethod(wrap_math_process_func(np.not_equal))
@@ -435,7 +435,7 @@ class Greater(BaseComparison):
       b (RasterBlock, number): Comparison parameter b
 
     Returns:
-      Rasterblock containing boolean values
+      RasterBlock containing boolean values
     """
 
     process = staticmethod(wrap_math_process_func(np.greater))
@@ -453,7 +453,7 @@ class GreaterEqual(BaseComparison):
       b (RasterBlock, number): Comparison parameter b
 
     Returns:
-      Rasterblock containing boolean values
+      RasterBlock containing boolean values
     """
 
     process = staticmethod(wrap_math_process_func(np.greater_equal))
@@ -471,7 +471,7 @@ class Less(BaseComparison):
       b (RasterBlock, number): Comparison parameter b
 
     Returns:
-      Rasterblock containing boolean values
+      RasterBlock containing boolean values
     """
     process = staticmethod(wrap_math_process_func(np.less))
 
@@ -488,7 +488,7 @@ class LessEqual(BaseComparison):
       b (RasterBlock, number): Comparison parameter b
 
     Returns:
-      Rasterblock containing boolean values
+      RasterBlock containing boolean values
     """
 
     process = staticmethod(wrap_math_process_func(np.less_equal))
@@ -504,7 +504,7 @@ class Invert(BaseSingle):
       x (RasterBlock): Boolean raster with values to invert
 
     Returns:
-      Rasterblock with boolean values opposite to the input raster. 
+      RasterBlock with boolean values opposite to the input raster. 
     """
 
     def __init__(self, x):
@@ -534,7 +534,7 @@ class IsData(BaseSingle):
       store (RasterBlock): Single input raster
 
     Returns:
-      Rasterblock with boolean values. 
+      RasterBlock with boolean values. 
     """
 
     def __init__(self, store):
@@ -569,7 +569,7 @@ class IsNoData(IsData):
       store (RasterBlock): Single input raster
 
     Returns:
-      Rasterblock with boolean values. 
+      RasterBlock with boolean values. 
     """
 
     @staticmethod
@@ -593,7 +593,7 @@ class And(BaseLogic):
       b (RasterBlock, boolean): Boolean input b
 
     Returns:
-      Rasterblock containing boolean values
+      RasterBlock containing boolean values
     """
 
     process = staticmethod(wrap_math_process_func(np.logical_and))
@@ -611,7 +611,7 @@ class Or(BaseLogic):
       b (RasterBlock, boolean): Boolean input b
 
     Returns:
-      Rasterblock containing boolean values
+      RasterBlock containing boolean values
     """
 
     process = staticmethod(wrap_math_process_func(np.logical_or))
@@ -629,7 +629,7 @@ class Xor(BaseLogic):
       b (RasterBlock, boolean): Boolean input b
 
     Returns:
-      Rasterblock containing boolean values
+      RasterBlock containing boolean values
     """
 
     process = staticmethod(wrap_math_process_func(np.logical_xor))
@@ -648,7 +648,7 @@ class FillNoData(BaseElementwise):
       a (list of rasters): list of rasters to be combined.
       
     Returns:
-      Rasterblock which shows input rasters from right to left, with 'no data' values being transparent
+      RasterBlock which shows input rasters from right to left, with 'no data' values being transparent
     """
 
     def __init__(self, *args):

--- a/dask_geomodeling/raster/misc.py
+++ b/dask_geomodeling/raster/misc.py
@@ -197,9 +197,9 @@ class Step(BaseSingle):
 
     Args:
       store (RasterBlock): The raster whose cell values are the input to the step function
-      value (number): The constant value which raster cells are compared to, defaults to 0
       left (number): Value given to cells lower than the input value, defaults to 0
       right (number): Value given to cells higher than the input value, defaults to 1
+      value (number): The constant value which raster cells are compared to, defaults to 0
       at (number): Value given to cells equal to the inport value, defaults to the average of left and right
 
     Returns:

--- a/dask_geomodeling/raster/misc.py
+++ b/dask_geomodeling/raster/misc.py
@@ -33,7 +33,7 @@ class Clip(BaseSingle):
       source (RasterBlock): Raster which is used as the extent of the output raster
 
     Returns:
-      Rasterblock which has values from store and the extent of source. 
+      RasterBlock which has values from store and the extent of source. 
     """
 
     def __init__(self, store, source):
@@ -116,7 +116,7 @@ class Mask(BaseSingle):
       value (number): The constant value to be given to 'data' values.
     
     Returns:
-      A Rasterblock containing a single value
+      A RasterBlock containing a single value
 
     """
 
@@ -163,7 +163,7 @@ class MaskBelow(BaseSingle):
       value (number): The constant value below which values are masked.
     
     Returns:
-      A Rasterblock where cells below the input value are converted to 'no data'
+      A RasterBlock where cells below the input value are converted to 'no data'
     """
 
     def __init__(self, store, value):
@@ -203,7 +203,7 @@ class Step(BaseSingle):
       at (number): Value given to cells equal to the inport value, defaults to the average of left and right
 
     Returns:
-      Rasterblock containing three values; left, right and at. 
+      RasterBlock containing three values; left, right and at. 
     
     """
 
@@ -262,8 +262,8 @@ class Classify(BaseSingle):
     """
     Classify raster data into binned categories
 
-    Takes a Rasterblock and classifies its values based on bins. The bins are supplied as a list of ascending bin edges.
-    The cells of the resulting raster are integers based in which bin the input cell falls. The lowest possible output cell value is 0 (input value lower than lowest bin edge). 
+    Takes a RasterBlock and classifies its values based on bins. The bins are supplied as a list of ascending bin edges.
+    For each raster cell this operation returns the index of the bin to which the raster cell belongs. The lowest possible output cell value is 0 (input value lower than lowest bin edge). 
     The highest possible output cell value is equal to the amount of supplied bin edges (input value higher than highest bin edge).
 
     Args:
@@ -272,7 +272,7 @@ class Classify(BaseSingle):
       right (boolean): whether the intervals include the right or the left bin edge, defaults to the left bin edge
     
     Returns:
-      Rasterblock with classified values
+      RasterBlock with classified values
 
     See also:
       https://docs.scipy.org/doc/numpy/reference/generated/numpy.digitize.html
@@ -340,7 +340,7 @@ class Reclassify(BaseSingle):
       select (boolean): Selection to only keep reclassified values, and set all other cells to 'no data'. Defaults to False. 
     
     Returns:
-      Rasterblock with reclassified values
+      RasterBlock with reclassified values
     """
 
     def __init__(self, store, data, select=False):

--- a/dask_geomodeling/raster/misc.py
+++ b/dask_geomodeling/raster/misc.py
@@ -676,7 +676,9 @@ class RasterizeWKT(RasterBlock):
     @property
     def extent(self):
         return tuple(
-            utils.shapely_transform(load_wkt(self.wkt), self.projection, "EPSG:4326").bounds
+            utils.shapely_transform(
+                load_wkt(self.wkt), self.projection, "EPSG:4326"
+            ).bounds
         )
 
     @property

--- a/dask_geomodeling/raster/spatial.py
+++ b/dask_geomodeling/raster/spatial.py
@@ -112,10 +112,10 @@ class Dilate(BaseSingle):
       values (list): Only cells with these values are dilated
 
     Returns:
-      Rasterblock where cells in values list are dilated
+      RasterBlock where cells in values list are dilated
     
     See also:
-      https://homepages.inf.ed.ac.uk/rbf/HIPR2/dilate.htm
+      https://en.wikipedia.org/wiki/Dilation_%28morphology%29
     """
 
     def __init__(self, store, values):
@@ -210,14 +210,14 @@ class Smooth(BaseSingle):
     
     Args:
       store (RasterBlock): Raster to be smoothed
-      size (scalar): Input parameter for the smoothing algorithm. The 'sigma' value for the Gaussian kernal equals ``size / 3``
-      fill (scalar): Value used for 'no data' values in the smoothing process. Defaults to 0. 
+      size (number): Input parameter for the smoothing algorithm. The 'sigma' value for the Gaussian kernal equals ``size / 3``
+      fill (number): Value used for 'no data' values in the smoothing process. Defaults to 0. 
 
     Returns:
       Smoothed raster
       
     See Also:
-      https://homepages.inf.ed.ac.uk/rbf/HIPR2/gsmooth.htm
+      https://en.wikipedia.org/wiki/Gaussian_blur
 
     """
 
@@ -304,10 +304,10 @@ class HillShade(BaseSingle):
 
     Args:
       store (RasterBlock): Raster to which the hillshade is applied
-      size (scalar): size of the effect, in projected units
-      altitude (scalar): Light source altitude in degrees, default to 45
-      azimuth (scalar): Light source azimuth in degrees, default to 315
-      fill (scalar): fill value to be used for 'no data' values during hillshading
+      size (number): size of the effect, in projected units
+      altitude (number): Light source altitude in degrees, default to 45
+      azimuth (number): Light source azimuth in degrees, default to 315
+      fill (number): fill value to be used for 'no data' values during hillshading
 
     Returns:
       Hillshaded raster

--- a/dask_geomodeling/raster/spatial.py
+++ b/dask_geomodeling/raster/spatial.py
@@ -104,15 +104,17 @@ class Dilate(BaseSingle):
     """
     Perform spatial dilation on specific cell values.
 
-    Cells with values in the supplied list are spatially dilated by one cell in each direction (including diagonals). 
+    Cells with values in the supplied list are spatially dilated by one cell
+    in each direction, including diagonals.
+
     Dilation is performed in the order of the values parameter.
     
     Args:
-      store (RasterBlock): Raster to perform dilation on
-      values (list): Only cells with these values are dilated
+      store (RasterBlock): Raster to perform dilation on.
+      values (list): Only cells with these values are dilated.
 
     Returns:
-      RasterBlock where cells in values list are dilated
+      RasterBlock where cells in values list are dilated.
     
     See also:
       https://en.wikipedia.org/wiki/Dilation_%28morphology%29
@@ -149,14 +151,15 @@ class MovingMax(BaseSingle):
     """
     Apply a spatial maximum filter to the data using a circular footprint.
     
-    Shows a spatial maximum for each cell, by looking in a circular foorprint around this cell. This can be used for visualization of sparse data.
+    This can be used for visualization of sparse data.
 
     Args:
-      store (RasterBlock): raster to which the filter is applied
-      size (integer): diameter of the circular footprint. This should always be an odd number larger than 1.
+      store (RasterBlock): Raster to which the filter is applied
+      size (integer): Diameter of the circular footprint. This should always be
+        an odd number larger than 1.
     
     Returns:
-      Raster showing the the maximum value inside the footprint of each input cell. 
+      RasterBlock with maximum values inside the footprint of each input cell.
     """
 
     def __init__(self, store, size):
@@ -204,17 +207,17 @@ class MovingMax(BaseSingle):
 
 class Smooth(BaseSingle):
     """
-    Smooth the values from a raster spatially using gaussian smoothing.
-    
-    Performs a spatial smoothing on the input raster. Uses a Gaussian smoothing algorithm. 
-    
+    Smooth the values from a raster spatially using Gaussian smoothing.
+
     Args:
       store (RasterBlock): Raster to be smoothed
-      size (number): Input parameter for the smoothing algorithm. The 'sigma' value for the Gaussian kernal equals ``size / 3``
-      fill (number): Value used for 'no data' values in the smoothing process. Defaults to 0. 
+      size (number): The extent of the smoothing in meters. The 'sigma' value
+        for the Gaussian kernal equals ``size / 3``.
+      fill (number): 'no data' are replaced by this value during smoothing,
+        defaults to 0.
 
     Returns:
-      Smoothed raster
+      RasterBlock with spatially smoothed values.
       
     See Also:
       https://en.wikipedia.org/wiki/Gaussian_blur
@@ -299,15 +302,13 @@ class Smooth(BaseSingle):
 class HillShade(BaseSingle):
     """
     Calculate a hillshade from the raster values.
-    
-    Performs a hillshade algorithm on the input raster. 
 
     Args:
-      store (RasterBlock): Raster to which the hillshade is applied
-      size (number): size of the effect, in projected units
-      altitude (number): Light source altitude in degrees, default to 45
-      azimuth (number): Light source azimuth in degrees, default to 315
-      fill (number): fill value to be used for 'no data' values during hillshading
+      store (RasterBlock): Raster to which the hillshade algorithm is applied.
+      size (number): Size of the effect in projected units.
+      altitude (number): Light source altitude in degrees, defaults to 45.
+      azimuth (number): Light source azimuth in degrees, defaults to 315.
+      fill (number): Fill value to be used for 'no data' values.
 
     Returns:
       Hillshaded raster

--- a/dask_geomodeling/raster/spatial.py
+++ b/dask_geomodeling/raster/spatial.py
@@ -102,14 +102,20 @@ def expand_request_meters(request, radius_m=1):
 
 class Dilate(BaseSingle):
     """
-    Perform binary dilation on specific values. Dilation is done in the
-    order of the values parameter.
+    Perform spatial dilation on specific cell values.
 
-    :param store: raster to perform dilation on
-    :param values: only dilate pixels that have these values
+    Cells with values in the supplied list are spatially dilated by one cell in each direction (including diagonals). 
+    Dilation is performed in the order of the values parameter.
+    
+    Args:
+      store (RasterBlock): Raster to perform dilation on
+      values (list): Only cells with these values are dilated
 
-    :type store: RasterBlock
-    :type values: list
+    Returns:
+      Rasterblock where cells in values list are dilated
+    
+    See also:
+      https://homepages.inf.ed.ac.uk/rbf/HIPR2/dilate.htm
     """
 
     def __init__(self, store, values):
@@ -142,14 +148,15 @@ class Dilate(BaseSingle):
 class MovingMax(BaseSingle):
     """
     Apply a spatial maximum filter to the data using a circular footprint.
+    
+    Shows a spatial maximum for each cell, by looking in a circular foorprint around this cell. This can be used for visualization of sparse data.
 
-    :param store: raster to apply the maximum filter on
-    :param size: diameter of the circular footprint in pixels
-
-    :type store: RasterBlock
-    :type store: int
-
-    This block can be used for visualization of sparse data.
+    Args:
+      store (RasterBlock): raster to which the filter is applied
+      size (integer): diameter of the circular footprint. This should always be an odd number larger than 1.
+    
+    Returns:
+      Raster showing the the maximum value inside the footprint of each input cell. 
     """
 
     def __init__(self, store, size):
@@ -198,21 +205,20 @@ class MovingMax(BaseSingle):
 class Smooth(BaseSingle):
     """
     Smooth the values from a raster spatially using gaussian smoothing.
+    
+    Performs a spatial smoothing on the input raster. Uses a Gaussian smoothing algorithm. 
+    
+    Args:
+      store (RasterBlock): Raster to be smoothed
+      size (scalar): Input parameter for the smoothing algorithm. The 'sigma' value for the Gaussian kernal equals ``size / 3``
+      fill (scalar): Value used for 'no data' values in the smoothing process. Defaults to 0. 
 
-    :param store: raster to smooth
-    :param size: size of the smoothing in meters. the 'sigma' of the
-        gaussian kernel equals ``size / 3``.
-    :param fill: fill value to be used for 'no data' values during
-        smoothing. The output will not have 'no data' values.
+    Returns:
+      Smoothed raster
+      
+    See Also:
+      https://homepages.inf.ed.ac.uk/rbf/HIPR2/gsmooth.htm
 
-    :type store: Store
-    :type size: scalar
-    :type fill: scalar
-
-    The challenge is to mitigate the edge effects whilst remaining
-    performant. If the necessary margin for smoothing is more than 6 pixels in
-    any direction, the approach used here is requesting a zoomed out geometry,
-    smooth that and zoom back in to the original region of interest.
     """
 
     MARGIN_THRESHOLD = 6
@@ -293,21 +299,21 @@ class Smooth(BaseSingle):
 class HillShade(BaseSingle):
     """
     Calculate a hillshade from the raster values.
+    
+    Performs a hillshade algorithm on the input raster. 
 
-    :param store: RasterBlock object
-    :param size: size of the effect, in projected units
-    :param altitude: Light source altitude in degrees. Default 45.
-    :param azimuth: Light source azimuth in degrees. Default 315.
-    :param fill: fill value to be used for 'no data' values during hillshading
+    Args:
+      store (RasterBlock): Raster to which the hillshade is applied
+      size (scalar): size of the effect, in projected units
+      altitude (scalar): Light source altitude in degrees, default to 45
+      azimuth (scalar): Light source azimuth in degrees, default to 315
+      fill (scalar): fill value to be used for 'no data' values during hillshading
 
-    :type store: RasterBlock
-    :type size: scalar
-    :type altitude: scalar
-    :type azimuth: scalar
-    :type fill: scalar
+    Returns:
+      Hillshaded raster
 
-    Hillshade, adapted from gdal algorithm. Smooths prior to shading to
-    keep it good looking even when zoomed beyond 1:1.
+    See also:
+      https://pro.arcgis.com/en/pro-app/tool-reference/3d-analyst/how-hillshade-works.htm
     """
 
     def __init__(self, store, altitude=45, azimuth=315, fill=0):

--- a/dask_geomodeling/raster/temporal.py
+++ b/dask_geomodeling/raster/temporal.py
@@ -33,7 +33,7 @@ class Snap(RasterBlock):
       index (RasterBlock): Snap values to the times from this block
 
     Returns: 
-      Temporal rasterblock with spatial properties of the store and temporal properties of the index 
+      Temporal RasterBlock with spatial properties of the store and temporal properties of the index 
     """
 
     def __init__(self, store, index):

--- a/dask_geomodeling/raster/temporal.py
+++ b/dask_geomodeling/raster/temporal.py
@@ -26,15 +26,20 @@ class Snap(RasterBlock):
     """
     Snap the time structure of a raster to that of another raster.
 
-    This operations allows to take the cell values from one raster (the store) and the temporal properties of another raster (the index). 
-    If the store is not a temporal raster, its cell values are copied to each timestep of the index raster. If the store is also a temporal raster, this operation looks at each index timestamp and takes the closest store timestamp as cell values.
-    
+    This operations allows to take the cell values from one raster ('store')
+    and the temporal properties of another raster ('index').
+
+    If the store is not a temporal raster, its cell values are copied to each
+    timestep of the index raster. If the store is also a temporal raster, this
+    operation looks at each 'index' timestamp and takes the closest 'store'
+    timestamp as cell values.
+
     Args:
-      store (RasterBlock): Return cell values from this block
-      index (RasterBlock): Snap values to the times from this block
+      store (RasterBlock): Return cell values from this raster
+      index (RasterBlock): Snap values to the timestamps from this raster
 
     Returns: 
-      Temporal RasterBlock with spatial properties of the store and temporal properties of the index 
+      RasterBlock with temporal properties of the index.
     """
 
     def __init__(self, store, index):
@@ -165,16 +170,17 @@ class Snap(RasterBlock):
 
 class Shift(BaseSingle):
     """
-    Shift a raster by some timedelta.
+    Shift a temporal raster by some timedelta.
 
-    Shifts all timestamps of a raster by a constant amount of time. A positivie timedelta shifts into the future and a negative timedelta shifts into the past. 
-    
+    A positive timedelta shifts into the future and a negative timedelta shifts
+    into the past.
+
     Args:
       store (RasterBlock): The store whose timestamps are to be shifted
-      time (integer): The timedelta to shift the store, supplied in milliseconds. 
+      time (integer): The timedelta to shift the store, in milliseconds.
 
     Returns:
-      RasterBlock with the same values as the input, but its timestamps shifted. 
+      RasterBlock with its timestamps shifted.
     """
 
     def __init__(self, store, time):
@@ -328,21 +334,31 @@ def count_not_nan(x, *args, **kwargs):
 
 class TemporalAggregate(BaseSingle):
     """
-    Resample raster in time.
+    Resample a raster in time.
     
-    This geoblock allows you to perform temporal aggregation of rasters. The timestep of the resuling raster is equal to the supplied frequency. 
-    An example application is calculating monthly averages of data which is gridded daily. 
+    This operation performs temporal aggregation of rasters, for example a
+    hourly average of data that has a 5 minute resolution.. The timedelta of
+    the resulting raster is determined by the 'frequency' parameter.
 
     Args:
       source (RasterBlock): The input raster whose timesteps are aggregated
-      frequency (string or None): the frequency to resample to, as pandas offset string (see references under 'See Also'). If this value is None, this block will return the temporal statistic over the complete time range, with output timestamp at the end of the source raster period. Defaults to None.
-      statistic (string): the type of statistic to perform. Can be one of ``'sum', 'count', 'min', 'max', 'mean', 'median', 'p<percentile>'``. Defaults to ``sum``
-      closed (string or None): Can be one of ``None``, ``'left'``, ``'right'``. Determines what side of the interval is closed when resampling. Defaults to None
-      label (string or None): Determines what side of the interval is used as output datetime. Defaults to None.
-      timezone (string): timezone to perform the resampling in, defaults to UTC.
-      
+      frequency (string or None): The frequency to resample to, as pandas
+        offset string (see the references below). If this value is None, this
+        block will return the temporal statistic over the complete time range,
+        with output timestamp at the end of the source raster period.
+        Defaults to None.
+      statistic (string): The type of statistic to perform. Can be one of
+        ``{"sum", "count", "min", "max", "mean", "median", "p<percentile>"}``.
+        Defaults to ``"sum"``.
+      closed (string or None): Determines what side of the interval is closed.
+        Can be ``"left"`` or ``"right"``. The default depends on the frequency.
+      label (string or None): Determines what side of the interval is closed.
+        Can be ``"left"`` or ``"right"``. The default depends on the frequency.
+      timezone (string): Timezone to perform the resampling in, defaults to
+        ``"UTC"``.
+
     Returns:
-      Temporally aggregated raster
+      RasterBlock with temporally aggregated data.
 
     See also:
       https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.resample.html
@@ -645,20 +661,27 @@ def accumulate_count_not_nan(x, *args, **kwargs):
 
 class Cumulative(BaseSingle):
     """
-    Geoblock that computes a cumulative of a raster over time.
-    
-    Contrary to ``dask_geomodeling.raster.temporal.TemporalAggregate``, in this geoblock the timestep of the resulting raster equals the timestep of the input raster. 
-    Cell values are accumulated over the supplied period. At the end of each period the accumulation is reset. 
-    
+    Compute the cumulative of a raster over time.
+
+    Contrary to ``dask_geomodeling.raster.temporal.TemporalAggregate``, in this
+    operation the timedelta of the resulting raster equals the timedelta of the
+    input raster. Cell values are accumulated over the supplied period. At the
+    end of each period the accumulation is reset.
+
     Args:
-      source (RasterBlock): The input raster whose cell values are accumulated.
-      statistic (string): The method of accumulation. Possibilities are ``sum`` and ``count``. Defaults to ``sum``.
-      period (string or None): the period over which the accumulation is performed. Supplied as a pandas offset string (see references under 'See Also'). If this value is None, the accumulation will continue indefinitely. Defaults to None.
-      timezone (string): Timezone in which the accumulation is performed, defaults to UTC.
+      source (RasterBlock): The input raster whose timesteps are accumulated.
+      statistic (string): The type of accumulation to perform. Can be ``"sum"``
+        or ``"count"``. Defaults to ``"sum"``.
+      frequency (string or None): The period over which accumulation is
+        performed. Supply a pandas offset string (see the references below). If
+        this value is None, the accumulation will continue indefinitely.
+        Defaults to None.
+      timezone (string): Timezone in which the accumulation is performed,
+        defaults to ``"UTC"``.
 
     Returns:
-      Temporal raster which is accumulated over the supplied period. 
-      
+      RasterBlock with temporally accumulated data.
+
     See also:
       https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#dateoffset-objects
     """

--- a/dask_geomodeling/tests/test_raster.py
+++ b/dask_geomodeling/tests/test_raster.py
@@ -1669,7 +1669,7 @@ class TestBase(unittest.TestCase):
         self.assertEqual(view.get_data(**self.time_request)["time"], self.expected_time)
 
     def test_step(self):
-        view = raster.Step(store=self.raster, location=0)
+        view = raster.Step(store=self.raster, value=0)
         view.get_data(**self.meta_request)
         view.get_data(**self.time_request)
 
@@ -1678,17 +1678,17 @@ class TestBase(unittest.TestCase):
         self.assertIsNone(data)
 
         # right value result (store returns 7)
-        view = raster.Step(store=self.raster, left=3, right=10, location=6)
+        view = raster.Step(store=self.raster, left=3, right=10, value=6)
         data = view.get_data(**self.vals_request)
         assert_equal(data["values"], 10)
 
         # left value result
-        view = raster.Step(store=self.raster, left=3, right=10, location=8)
+        view = raster.Step(store=self.raster, left=3, right=10, value=8)
         data = view.get_data(**self.vals_request)
         assert_equal(data["values"], 3)
 
         # at value result
-        view = raster.Step(store=self.raster, at=15, location=7)
+        view = raster.Step(store=self.raster, at=15, value=7)
         data = view.get_data(**self.vals_request)
         assert_equal(data["values"], 15)
 

--- a/docs/raster.rst
+++ b/docs/raster.rst
@@ -1,8 +1,13 @@
 Raster Blocks
 =============
 
-Raster-type blocks contain rasters with a time axis. Internally, the raster
-data is stored as `NumPy <https://numpy.org/>`_ arrays.
+RasterBlocks are the main component of geoblocks raster operations. 
+Every raster operation takes one or more rasterblocks as input and produces
+a single rasterblock as output.
+Raster-type blocks contain rasters with data in three dimensions. Besides the
+x- and y-axes they also have a temporal axis.
+
+Internally, dask-geomodeling stores the raster data as `NumPy <https://numpy.org/>`_ arrays.
 
 API Specification
 -----------------
@@ -32,7 +37,7 @@ API Specification
 
 .. automodule:: dask_geomodeling.raster.misc
    :members:
-   :exclude-members: get_sources_and_requests, process
+   :exclude-members: get_sources_and_requests, process, extent, geometry
 
 
 :mod:`dask_geomodeling.raster.sources`

--- a/docs/raster.rst
+++ b/docs/raster.rst
@@ -1,13 +1,15 @@
 Raster Blocks
 =============
 
-RasterBlocks are the main component of geoblocks raster operations. 
-Every raster operation takes one or more rasterblocks as input and produces
-a single rasterblock as output.
+RasterBlocks are the main component of raster operations. Most raster
+operations take one or more RasterBlocks as input and produce a single
+RasterBlock as output.
+
 Raster-type blocks contain rasters with data in three dimensions. Besides the
 x- and y-axes they also have a temporal axis.
 
-Internally, dask-geomodeling stores the raster data as `NumPy <https://numpy.org/>`_ arrays.
+Internally, dask-geomodeling stores the raster data as
+`NumPy <https://numpy.org/>`_ arrays.
 
 API Specification
 -----------------


### PR DESCRIPTION
@mdkrol I added some adaptations on top of #24 :

 - fixed line endings
 - removed duplicate sentences
 - fixed English here and there
 - removed all references to geoblocks (this is dask-geomodeling here)
 - replaced 'location' by 'value' in the Step geoblock
 - I did not replace 'frequency' by 'period' in the Cumulative. 'period' is a reserved word, it describes the period in which the RasterBlock has data. Also it would add some work in Lizard, I think it is not worth the effort.

If you want to look through it one more time, comment, then I'll finish it and merge.