### PR TITLE
Place block

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of dask-geomodeling
 2.2.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added raster.spatial.Place.
 
 
 2.2.2 (2020-02-13)

--- a/dask_geomodeling/raster/spatial.py
+++ b/dask_geomodeling/raster/spatial.py
@@ -531,24 +531,11 @@ class Place(BaseSingle):
         if not store_geometry.GetSpatialReference().IsSame(sr):
             store_geometry = store_geometry.Clone()
             store_geometry.TransformTo(sr)
-        x1, x2, y1, y2 = store_geometry.GetEnvelope()
-
-        extents = []
-        for _x, _y in self.coordinates:
-            extents.append(
-                [
-                    x1 - self.anchor[0] + _x,
-                    y1 - self.anchor[1] + _y,
-                    x2 - self.anchor[0] + _x,
-                    y2 - self.anchor[1] + _y,
-                ]
-            )
-
-        # join the extents
-        x1 = min([e[0] for e in extents])
-        y1 = min([e[1] for e in extents])
-        x2 = max([e[2] for e in extents])
-        y2 = max([e[3] for e in extents])
+         _x1, _x2, _y1, _y2 = store_geometry.GetEnvelope()
+         p, q = self.anchor
+         P, Q = zip(*self.coordinates)
+         x1, x2 = _x1 + min(P) - p, _x2 + max(P) - p
+         y1, y2 = _y1 + min(Q) - q, _y2 + max(Q) - q
         return ogr.CreateGeometryFromWkt(POLYGON.format(x1, y1, x2, y2), sr)
 
     def get_sources_and_requests(self, **request):

--- a/dask_geomodeling/tests/test_raster_spatial.py
+++ b/dask_geomodeling/tests/test_raster_spatial.py
@@ -34,6 +34,7 @@ def vals_request(request):
         height=int(bbox[3] / 10),
     )
 
+
 @pytest.fixture
 def empty():
     yield MemorySource(
@@ -107,6 +108,8 @@ def test_place_empty(empty, center, vals_request):
 def test_place_exact(source, center, vals_request):
     place = raster.Place(source, "EPSG:28992", center, [(50, 50)])
     values = place.get_data(**vals_request)["values"]
+    # swap Y axis for readable test
+    values = values[:, ::-1, :]
     assert (values[:, :10, :10] == 7).all()
 
 
@@ -128,6 +131,8 @@ def test_place_horizontal_shift(source, center, vals_request):
     # shift 1 cell (10 meters) to the right
     place = raster.Place(source, "EPSG:28992", center, [(60, 50)])
     values = place.get_data(**vals_request)["values"]
+    # swap Y axis for readable test
+    values = values[:, ::-1, :]
     assert (values[:, :10, 1:11] == 7).all()
     assert (values[:, :, 0] == 255).all()
 
@@ -136,19 +141,21 @@ def test_place_vertical_shift(source, center, vals_request):
     # shift 1 cell (10 meters) up
     place = raster.Place(source, "EPSG:28992", center, [(50, 60)])
     values = place.get_data(**vals_request)["values"]
-    # swap Y axis for test
+    # swap Y axis for readable test
     values = values[:, ::-1, :]
     assert (values[:, 1:11, :10] == 7).all()
-    assert (values[:, 0, :10] == 255).all()
+    assert (values[:, 0, :] == 255).all()
 
 
 def test_place_multiple(source, center, vals_request):
     # place such that only the left and bottom ridges have values
     place = raster.Place(source, "EPSG:28992", center, [(-40, 50), (50, -40)])
     values = place.get_data(**vals_request)["values"]
-    assert (values[:, :, 0] == 7).all()
-    assert (values[:, -1, :] == 7).all()
-    assert (values[:, :-1, 1:] == 255).all()
+    # swap Y axis for readable test
+    values = values[:, ::-1, :]
+    assert (values[:, :10, 0] == 7).all()
+    assert (values[:, 0, :10] == 7).all()
+    assert (values[:, 1:, 1:] == 255).all()
 
 
 def test_place_outside(source, center, vals_request):

--- a/dask_geomodeling/tests/test_raster_spatial.py
+++ b/dask_geomodeling/tests/test_raster_spatial.py
@@ -1,0 +1,58 @@
+from datetime import datetime, timedelta
+
+import numpy as np
+import pytest
+from numpy.testing import assert_equal, assert_almost_equal
+from shapely.geometry import box
+
+from dask_geomodeling import raster
+from dask_geomodeling.utils import shapely_transform, get_sr
+from dask_geomodeling.raster.sources import MemorySource
+
+
+@pytest.fixture
+def source():
+    yield MemorySource(
+        data=np.full((1, 10, 10), 7, dtype=np.uint8),
+        no_data_value=255,
+        projection="EPSG:28992",
+        pixel_size=10,
+        pixel_origin=(135000, 456000),
+    )
+
+@pytest.fixture
+def center():
+    # the source raster has data at x 135000..135100 and y 456000..455900
+    yield 135050, 455950
+
+
+def test_place_attrs(source):
+    # clip should propagate the (empty) extent of the store
+    place = raster.Place(source, "EPSG:28992", (135000, 456000), [(0, 0)])
+    assert place.extent is None  # TODO shifted extent
+    assert place.geometry is None  # TODO shifted geometry
+
+
+def test_place_exact(source, center):
+    place = raster.Place(source, "EPSG:28992", center, [(50, 50)])
+    values = place.get_data(
+        mode="vals",
+        bbox=(0, 0, 100, 100),
+        projection="EPSG:28992",
+        width=10,
+        height=10,
+    )["values"]
+    assert (values == 7).all()
+
+
+def test_place_half(source, center):
+    place = raster.Place(source, "EPSG:28992", center, [(0, 50)])
+    values = place.get_data(
+        mode="vals",
+        bbox=(0, 0, 100, 100),
+        projection="EPSG:28992",
+        width=5,
+        height=5,
+    )["values"]
+    assert (values[:, :, :4] == 7).all()
+    assert (values[:, :, 6:] == 255).all()

--- a/dask_geomodeling/tests/test_raster_spatial.py
+++ b/dask_geomodeling/tests/test_raster_spatial.py
@@ -1,12 +1,9 @@
-from datetime import datetime, timedelta
-
 import numpy as np
 import pytest
-from numpy.testing import assert_equal, assert_almost_equal
-from shapely.geometry import box
+from shapely.geometry import box, Point
 
 from dask_geomodeling import raster
-from dask_geomodeling.utils import shapely_transform, get_sr
+from dask_geomodeling.utils import shapely_transform
 from dask_geomodeling.raster.sources import MemorySource
 
 
@@ -20,39 +17,123 @@ def source():
         pixel_origin=(135000, 456000),
     )
 
+
 @pytest.fixture
 def center():
     # the source raster has data at x 135000..135100 and y 456000..455900
     yield 135050, 455950
 
 
-def test_place_attrs(source):
-    # clip should propagate the (empty) extent of the store
-    place = raster.Place(source, "EPSG:28992", (135000, 456000), [(0, 0)])
-    assert place.extent is None  # TODO shifted extent
-    assert place.geometry is None  # TODO shifted geometry
+@pytest.fixture
+def center_epsg3857(center):
+    yield shapely_transform(Point(*center), "EPSG:28992", "EPSG:3857").coords[0]
+
+
+def test_place_attrs(source, center):
+    place = raster.Place(source, "EPSG:28992", center, [(50, 50)])
+
+    # Place should not adapt these attributes:
+    assert place.period == source.period
+    assert place.timedelta == source.timedelta
+    assert place.dtype == source.dtype
+    assert place.fillvalue == source.fillvalue
+
+    # If the place projection equals the store projection:
+    assert place.projection == source.projection
+    assert place.geo_transform == source.geo_transform
+
+    extent_epsg28992 = (0, 0, 100, 100)
+    extent_epsg4326 = shapely_transform(
+        box(*extent_epsg28992), "EPSG:28992", "EPSG:4326"
+    ).bounds
+    x1, x2, y1, y2 = place.geometry.GetEnvelope()
+    assert (x1, y1, x2, y2) == extent_epsg28992
+    assert place.extent == pytest.approx(extent_epsg4326, rel=1e-4)
+
+
+def test_place_attrs_reproject(source, center_epsg3857):
+    # Place should adapt the spatial attributes (extent & geometry)
+    place = raster.Place(
+        source, "EPSG:3857", center_epsg3857, [(572050, 6812050), (570050, 6811050)]
+    )
+    # The native projection != store projection:
+    assert place.projection is None
+    assert place.geo_transform is None
+
+    extent_epsg3857 = 570000, 6811000, 572100, 6812100
+    extent_epsg4326 = shapely_transform(
+        box(*extent_epsg3857), "EPSG:3857", "EPSG:4326"
+    ).bounds
+    x1, x2, y1, y2 = place.geometry.GetEnvelope()
+    assert (x1, y1, x2, y2) == pytest.approx(extent_epsg3857, rel=1e-4)
+    assert place.extent == pytest.approx(extent_epsg4326, rel=1e-4)
 
 
 def test_place_exact(source, center):
     place = raster.Place(source, "EPSG:28992", center, [(50, 50)])
     values = place.get_data(
-        mode="vals",
-        bbox=(0, 0, 100, 100),
-        projection="EPSG:28992",
-        width=10,
-        height=10,
+        mode="vals", bbox=(0, 0, 100, 100), projection="EPSG:28992", width=10, height=10
     )["values"]
     assert (values == 7).all()
 
 
-def test_place_half(source, center):
-    place = raster.Place(source, "EPSG:28992", center, [(0, 50)])
+def test_place_reproject(source, center_epsg3857):
+    target = 572050, 6812050  # EPSG3857 coords somewhere inside RD validity
+    place = raster.Place(source, "EPSG:3857", center_epsg3857, [target])
+    x, y = shapely_transform(Point(*target), "EPSG:3857", "EPSG:28992").coords[0]
     values = place.get_data(
         mode="vals",
-        bbox=(0, 0, 100, 100),
+        bbox=(x - 40, y - 40, x + 40, y + 40),
         projection="EPSG:28992",
-        width=5,
-        height=5,
+        width=8,
+        height=8,
     )["values"]
-    assert (values[:, :, :4] == 7).all()
-    assert (values[:, :, 6:] == 255).all()
+    assert (values == 7).all()
+
+
+def test_place_horizontal_shift(source, center):
+    # shift 1 cell (10 meters) to the left
+    place = raster.Place(source, "EPSG:28992", center, [(40, 50)])
+    values = place.get_data(
+        mode="vals", bbox=(0, 0, 100, 100), projection="EPSG:28992", width=10, height=10
+    )["values"]
+    assert (values[:, :, :9] == 7).all()
+    assert (values[:, :, 9] == 255).all()
+
+
+def test_place_vertical_shift(source, center):
+    # shift 1 cell (10 meters) down (y axis is flipped)
+    place = raster.Place(source, "EPSG:28992", center, [(50, 60)])
+    values = place.get_data(
+        mode="vals", bbox=(0, 0, 100, 100), projection="EPSG:28992", width=10, height=10
+    )["values"]
+    assert (values[:, :9, :] == 7).all()
+    assert (values[:, 9, :] == 255).all()
+
+
+def test_place_multiple(source, center):
+    # place such that only the left and right ridges have values
+    place = raster.Place(source, "EPSG:28992", center, [(-40, 50), (140, 50)])
+    values = place.get_data(
+        mode="vals", bbox=(0, 0, 100, 100), projection="EPSG:28992", width=10, height=10
+    )["values"]
+    assert (values[:, :, 1:-1] == 255).all()
+    assert (values[:, :, (0, 9)] == 7).all()
+
+
+def test_place_outside(source, center):
+    place = raster.Place(source, "EPSG:28992", center, [(150, 50)])
+    values = place.get_data(
+        mode="vals", bbox=(0, 0, 100, 100), projection="EPSG:28992", width=10, height=10
+    )["values"]
+    assert (values[:, :, :] == 255).all()
+
+
+def test_place_time_request(source, center):
+    place = raster.Place(source, "EPSG:28992", center, [(150, 50)])
+    assert source.get_data(mode="time") == place.get_data(mode="time")
+
+
+def test_place_meta_request(source, center):
+    place = raster.Place(source, "EPSG:28992", center, [(150, 50)])
+    assert source.get_data(mode="meta") == place.get_data(mode="meta")

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,6 @@ filterwarnings =
     error:::scipy[.*]
     error:::pandas[.*]
     error:::dask[.*]
+
+[flake8]
+ignore = E203, E266, E501, W503

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ install_requires = (
         "pytz",
         "numpy>=1.12",
         "scipy>=0.19",
+        "pyproj",
     ],
 )
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ install_requires = (
         "pytz",
         "numpy>=1.12",
         "scipy>=0.19",
-        "pyproj",
     ],
 )
 


### PR DESCRIPTION
This adds a RasterBlock that can place one raster at given coordinate. For example, you have a 'tree' raster and you want to place it at multiple locations. What you would do is:

```
tree = RasterFileSource("tree.tiff")
forest = Place(tree, "EPSG:3857", [<center of the tree in tree.tiff], [<target coord 1>, <target coord 2>, ...])
```

There are some nice subtleties about reprojections in here. You potentially have 3 different ones:
 1. the native projection of tree.tiff
 2. the projection in which the place is done
 3. the projection of the data request

What I do is:
 - reproject the "anchor" and "coordinates" from the place-projection (2) to the requested projection (3)
 - shift the requested bounding box according to the (anchor - coordinate) differences, all in the requested projection (3)
 - rasterstore takes care about reprojecting from the native one to the requested one (1 -> 3)

The result is that the reprojection takes place at the original coordinate. This might give some funny results (trees may inflate or deflate if you shift them a long distance)