### PR TITLE
Allow 1E-7 of tilt in geotransform

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog of dask-geomodeling
 2.2.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Allow up to 1E-7 in the GeoTransform 'tilt' terms to account for possible
+  float32 imprecision.
 
 
 2.2.3 (2020-02-28)

--- a/dask_geomodeling/tests/test_utils.py
+++ b/dask_geomodeling/tests/test_utils.py
@@ -229,6 +229,10 @@ class TestGeoTransform(unittest.TestCase):
         # with a tilt
         self.assertRaises(ValueError, utils.GeoTransform, (0, 1, 1, 0, 0, 1))
         self.assertRaises(ValueError, utils.GeoTransform, (0, 1, 0, 0, 1, 1))
+        # allow some space for float32 imprecision
+        self.assertRaises(ValueError, utils.GeoTransform, (0, 1, 0, 0, 1e-6, 1))
+        self.assertRaises(ValueError, utils.GeoTransform, (0, 1, 1e-6, 0, 0, 1))
+        utils.GeoTransform((0, 1, 1e-8, 0, -1e-8, 1))
 
     def test_compare(self):
         for matching in (

--- a/dask_geomodeling/utils.py
+++ b/dask_geomodeling/utils.py
@@ -19,7 +19,7 @@ from shapely import wkb as shapely_wkb
 import fiona
 
 POLYGON = "POLYGON (({0} {1},{2} {1},{2} {3},{0} {3},{0} {1}))"
-
+FLOAT_PRECISION = 1e-7
 
 try:
     from fiona import Env as fiona_env  # NOQA
@@ -171,7 +171,7 @@ class GeoTransform(tuple):
     def __init__(self, tpl):
         if len(tpl) != 6:
             raise ValueError("GeoTransform expected an iterable of length 6")
-        if tpl[2] != 0.0 or tpl[4] != 0.0:
+        if abs(tpl[2]) > FLOAT_PRECISION or abs(tpl[4]) > FLOAT_PRECISION:
             raise ValueError("Tilted geo_transforms are not supported")
         if tpl[1] == 0.0 or tpl[5] == 0.0:
             raise ValueError("Pixel size should not be zero")

--- a/dask_geomodeling/utils.py
+++ b/dask_geomodeling/utils.py
@@ -1,4 +1,5 @@
 import re
+import math
 import pytz
 import os
 import warnings
@@ -19,7 +20,6 @@ from shapely import wkb as shapely_wkb
 import fiona
 
 POLYGON = "POLYGON (({0} {1},{2} {1},{2} {3},{0} {3},{0} {1}))"
-FLOAT_PRECISION = 1e-7
 
 try:
     from fiona import Env as fiona_env  # NOQA
@@ -171,9 +171,9 @@ class GeoTransform(tuple):
     def __init__(self, tpl):
         if len(tpl) != 6:
             raise ValueError("GeoTransform expected an iterable of length 6")
-        if abs(tpl[2]) > FLOAT_PRECISION or abs(tpl[4]) > FLOAT_PRECISION:
+        if not all(math.isclose(tpl[i], 0.0, abs_tol=1e-7) for i in (2, 4)):
             raise ValueError("Tilted geo_transforms are not supported")
-        if tpl[1] == 0.0 or tpl[5] == 0.0:
+        if any(math.isclose(tpl[i], 0.0, abs_tol=1e-7) for i in (1, 5)):
             raise ValueError("Pixel size should not be zero")
 
     def __repr__(self):


### PR DESCRIPTION
According to google, float32 will guarantee only 7 decimals of precision. GDAL uses float32.

When we convert to float64 (Python) and then check if it is 0, we could have some float imprecision issues.