### PR TITLE
Export crashes on fields with lists

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@ Changelog of dask-geomodeling
 2.2.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Accept list and dict values in GeometryFileSink / to_file.
+
+- Fix bug in ParseTextColumn that added columns in duplicate when outputting
+  into the input column.
 
 
 2.2.6 (2020-04-28)

--- a/dask_geomodeling/geometry/text.py
+++ b/dask_geomodeling/geometry/text.py
@@ -1,6 +1,7 @@
 """
 Module containing text column operations that act on geometry blocks
 """
+import numpy as np
 import pandas as pd
 import re
 
@@ -95,7 +96,9 @@ class ParseTextColumn(BaseSingle):
 
         if len(column.cat.categories) == 0:
             # no data to parse: add empty columns and return directly
-            f = f.reindex(columns=list(f.columns) + list(key_mapping.values()))
+            f = f.copy()
+            for col in key_mapping.values():
+                f[col] = np.nan
             return {"features": f, "projection": data["projection"]}
 
         def parser(description):


### PR DESCRIPTION
This solves two issues:
 - ParseTextColumn doesn't add columns in duplicate anymore when outputting to the input field and when there are no values.
 - Exports now can accept list and dict values in the fields

https://nelen-schuurmans.atlassian.net/browse/BACK-768
