### PR TITLE
Fix geopandas 0.7 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ etc/*.logrotate
 
 # ignore docs
 docs/_*
+
+notebooks
+*.ipynb

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
     env: PYTHON_VERSION="3.6" MAINDEPS="numpy=1.14 gdal=2.2.4 scipy=1.1 pytz" DEPS="dask-core=0.20 toolz=0.10 pandas=0.23 geopandas=0.5"
   - os: linux
     env: PYTHON_VERSION="3.7" MAINDEPS="numpy gdal=2.* scipy pytz" DEPS="dask-core toolz geopandas"
+  - os: linux
+    env: PYTHON_VERSION="3.8" MAINDEPS="numpy gdal scipy pytz" DEPS="dask-core toolz geopandas"
   - os: osx
     env: PYTHON_VERSION="3.7" MAINDEPS="numpy gdal=2.* scipy pytz" DEPS="dask-core toolz geopandas"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ matrix:
   - os: linux
     env: PYTHON_VERSION="3.7" MAINDEPS="numpy scipy pytz" DEPS="dask-core gdal=2.* toolz geopandas pyproj>=2"
   - os: linux
-    env: PYTHON_VERSION="3.8" MAINDEPS="numpy scipy pytz" DEPS="dask-core gdal toolz geopandas pyproj>=2"
+    env: PYTHON_VERSION="3.8" MAINDEPS="numpy scipy pytz" DEPS="dask-core gdal=2.* toolz geopandas pyproj>=2"
   - os: osx
-    env: PYTHON_VERSION="3.7" MAINDEPS="numpy scipy pytz" DEPS="dask-core gdal toolz geopandas pyproj>=2"
+    env: PYTHON_VERSION="3.7" MAINDEPS="numpy scipy pytz" DEPS="dask-core gdal=2.* toolz geopandas pyproj>=2"
 
 install:
   - wget https://repo.anaconda.com/pkgs/misc/conda-execs/conda-latest-$TRAVIS_OS_NAME-64.exe -O conda.exe

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ matrix:
     env: PYTHON_VERSION="3.6" MAINDEPS="numpy=1.14 gdal=2.2.4 scipy=1.1 pytz" DEPS="dask-core=0.20 toolz=0.10 pandas=0.23 geopandas=0.5"
   - os: linux
     env: PYTHON_VERSION="3.7" MAINDEPS="numpy scipy pytz" DEPS="dask-core gdal=2.* toolz geopandas pyproj>=2"
-  - os: linux
-    env: PYTHON_VERSION="3.8" MAINDEPS="numpy scipy pytz" DEPS="dask-core gdal=2.* toolz geopandas pyproj>=2"
   - os: osx
     env: PYTHON_VERSION="3.7" MAINDEPS="numpy scipy pytz" DEPS="dask-core gdal=2.* toolz geopandas pyproj>=2"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ matrix:
   - os: linux
     env: PYTHON_VERSION="3.6" MAINDEPS="numpy=1.14 gdal=2.2.4 scipy=1.1 pytz" DEPS="dask-core=0.20 toolz=0.10 pandas=0.23 geopandas=0.5"
   - os: linux
-    env: PYTHON_VERSION="3.7" MAINDEPS="numpy gdal=2.* scipy pytz" DEPS="dask-core toolz geopandas"
+    env: PYTHON_VERSION="3.7" MAINDEPS="numpy scipy pytz" DEPS="dask-core gdal=2.* toolz geopandas pyproj>=2"
   - os: linux
-    env: PYTHON_VERSION="3.8" MAINDEPS="numpy gdal scipy pytz" DEPS="dask-core toolz geopandas"
+    env: PYTHON_VERSION="3.8" MAINDEPS="numpy scipy pytz" DEPS="dask-core gdal toolz geopandas pyproj>=2"
   - os: osx
-    env: PYTHON_VERSION="3.7" MAINDEPS="numpy gdal=2.* scipy pytz" DEPS="dask-core toolz geopandas"
+    env: PYTHON_VERSION="3.7" MAINDEPS="numpy scipy pytz" DEPS="dask-core gdal toolz geopandas pyproj>=2"
 
 install:
   - wget https://repo.anaconda.com/pkgs/misc/conda-execs/conda-latest-$TRAVIS_OS_NAME-64.exe -O conda.exe

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Changelog of dask-geomodeling
 - Fix bug in ParseTextColumn that added columns in duplicate when outputting
   into the input column.
 
+- Fixed incompatibilities with geopandas >=0.7.
+
 
 2.2.6 (2020-04-28)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Changelog of dask-geomodeling
 
 - Fixed incompatibilities with geopandas >=0.7.
 
+- GeoJSON output is always converted to EPSG:4326 and doesn't have "crs" field.
+
 
 2.2.6 (2020-04-28)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ Changelog of dask-geomodeling
 
 - Accept categorical values in GeometryFileSink / to_file.
 
+- Fixed incompatibilities with geopandas >=0.7.
+
+- GeoJSON output is always converted to EPSG:4326 and doesn't have "crs" field.
+
 
 2.2.7 (2020-04-30)
 ------------------
@@ -14,10 +18,6 @@ Changelog of dask-geomodeling
 
 - Fix bug in ParseTextColumn that added columns in duplicate when outputting
   into the input column.
-
-- Fixed incompatibilities with geopandas >=0.7.
-
-- GeoJSON output is always converted to EPSG:4326 and doesn't have "crs" field.
 
 
 2.2.6 (2020-04-28)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,11 @@ environment:
   matrix:
     - PYTHON_PATH: "C:\\Miniconda37"
       PYTHON_VERSION: 3.7
-      DEPS: "numpy gdal=2.* scipy pytz dask-core toolz geopandas"
+      DEPS: "numpy gdal scipy pytz dask-core toolz geopandas pyproj>=2"
 
     - PYTHON_PATH: "C:\\Miniconda37-x64"
       PYTHON_VERSION: 3.7
-      DEPS: "numpy gdal=2.* scipy pytz dask-core toolz geopandas"
+      DEPS: "numpy gdal scipy pytz dask-core toolz geopandas pyproj>=2"
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,11 @@ environment:
   matrix:
     - PYTHON_PATH: "C:\\Miniconda37"
       PYTHON_VERSION: 3.7
-      DEPS: "numpy gdal scipy pytz dask-core toolz geopandas pyproj>=2"
+      DEPS: "numpy gdal=2.* scipy pytz dask-core toolz geopandas pyproj>=2"
 
     - PYTHON_PATH: "C:\\Miniconda37-x64"
       PYTHON_VERSION: 3.7
-      DEPS: "numpy gdal scipy pytz dask-core toolz geopandas pyproj>=2"
+      DEPS: "numpy gdal=2.* scipy pytz dask-core toolz geopandas pyproj>=2"
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION%"

--- a/dask_geomodeling/geometry/merge.py
+++ b/dask_geomodeling/geometry/merge.py
@@ -12,12 +12,12 @@ __all__ = ["MergeGeometryBlocks"]
 class MergeGeometryBlocks(GeometryBlock):
     """
     Merge two GeometryBlocks into one by index
-    
-    Provide two GeometryBlocks with the same original source to make sure they 
+
+    Provide two GeometryBlocks with the same original source to make sure they
     can be matched on index. The additional SeriesBlocks that have been added
     to the GeometryBlock will be combined to one GeometryBlock that contains
     all the information.
-    
+
     Args:
       left (GeometryBlock): The left GeometryBlock to be combined.
       right (GeometryBlock): The right GeometryBlock to be combined.
@@ -35,7 +35,7 @@ class MergeGeometryBlocks(GeometryBlock):
         4. ``outer``: The result will contain all the features which are
            present in one of the input GeometryBlocs.
       suffixes (tuple, optional): Text to be added to the column
-        names to distinguish whether they originate from the left or right 
+        names to distinguish whether they originate from the left or right
         GeometryBlock. Default: ``("", "_right")``.
 
     Returns:

--- a/dask_geomodeling/geometry/sources.py
+++ b/dask_geomodeling/geometry/sources.py
@@ -3,7 +3,6 @@ Module containing geometry sources.
 """
 import fiona
 import geopandas as gpd
-from shapely.geometry import box
 
 from dask import config
 from dask_geomodeling import utils
@@ -240,9 +239,9 @@ class GeometryWKTSource(GeometryBlock):
         elif mode == 'centroid':
             if not geometry.centroid.intersects(request["geometry"]):
                 return {
-                        "projection": request["projection"],
-                        "features": gpd.GeoDataFrame([]),
-                    }
+                    "projection": request["projection"],
+                    "features": gpd.GeoDataFrame([]),
+                }
             return {"features": f, "projection": request['projection']}
 
         elif mode == 'extent':

--- a/dask_geomodeling/geometry/sources.py
+++ b/dask_geomodeling/geometry/sources.py
@@ -85,7 +85,7 @@ class GeometryFileSource(GeometryBlock):
     def process(url, request):
         path = utils.safe_abspath(url)
 
-        # convert the requested projection to a fiona CRS
+        # convert the requested projection to a geopandas CRS
         crs = utils.get_crs(request["projection"])
 
         # convert the requested shapely geometry object to a GeoSeries

--- a/dask_geomodeling/tests/factories.py
+++ b/dask_geomodeling/tests/factories.py
@@ -7,7 +7,6 @@ from osgeo import osr, gdal
 
 import geopandas as gpd
 from shapely.geometry import Polygon
-from pyproj import CRS
 
 from dask import config
 from dask_geomodeling.config import defaults
@@ -16,6 +15,7 @@ from dask_geomodeling.raster import RasterBlock
 from dask_geomodeling.utils import (
     get_dtype_max,
     Extent,
+    get_crs,
     get_sr,
     get_epsg_or_wkt,
     shapely_transform,
@@ -237,7 +237,7 @@ class MockGeometry(GeometryBlock):
         mode = request.get("mode", "intersects")
 
         geoseries = gpd.GeoSeries(
-            [Polygon(x) for x in polygons], crs=CRS(projection)
+            [Polygon(x) for x in polygons], crs=get_crs(projection)
         )
 
         if get_epsg_or_wkt(projection) != get_epsg_or_wkt(request["projection"]):

--- a/dask_geomodeling/tests/factories.py
+++ b/dask_geomodeling/tests/factories.py
@@ -7,6 +7,7 @@ from osgeo import osr, gdal
 
 import geopandas as gpd
 from shapely.geometry import Polygon
+from pyproj import CRS
 
 from dask import config
 from dask_geomodeling.config import defaults
@@ -16,7 +17,6 @@ from dask_geomodeling.utils import (
     get_dtype_max,
     Extent,
     get_sr,
-    get_crs,
     get_epsg_or_wkt,
     shapely_transform,
     Dataset,
@@ -237,7 +237,7 @@ class MockGeometry(GeometryBlock):
         mode = request.get("mode", "intersects")
 
         geoseries = gpd.GeoSeries(
-            [Polygon(x) for x in polygons], crs=get_crs(projection)
+            [Polygon(x) for x in polygons], crs=CRS(projection)
         )
 
         if get_epsg_or_wkt(projection) != get_epsg_or_wkt(request["projection"]):

--- a/dask_geomodeling/tests/test_geometry.py
+++ b/dask_geomodeling/tests/test_geometry.py
@@ -156,7 +156,11 @@ class TestGeometryFileSource(unittest.TestCase):
         bbox3857 = extent.transformed(get_sr("EPSG:3857")).bbox
         result = self.source.get_data(geometry=box(*bbox3857), projection="EPSG:3857")
         self.assertEqual("EPSG:3857", result["projection"])
-        self.assertEqual("EPSG:3857", result["features"].crs.to_string())
+        actual = result["features"].crs
+        if isinstance(actual, dict):  # pre-geopandas 0.7
+            self.assertEqual("epsg:3857", actual["init"])
+        else:  # geopandas >=0.7
+            self.assertEqual("EPSG:3857", actual.to_string())
         self.assertEqual(10, len(result["features"]))
 
     def test_limit(self):

--- a/dask_geomodeling/tests/test_geometry.py
+++ b/dask_geomodeling/tests/test_geometry.py
@@ -156,7 +156,7 @@ class TestGeometryFileSource(unittest.TestCase):
         bbox3857 = extent.transformed(get_sr("EPSG:3857")).bbox
         result = self.source.get_data(geometry=box(*bbox3857), projection="EPSG:3857")
         self.assertEqual("EPSG:3857", result["projection"])
-        self.assertEqual("epsg:3857", result["features"].crs["init"])
+        self.assertEqual("EPSG:3857", result["features"].crs.to_string())
         self.assertEqual(10, len(result["features"]))
 
     def test_limit(self):

--- a/dask_geomodeling/tests/test_geometry_sinks.py
+++ b/dask_geomodeling/tests/test_geometry_sinks.py
@@ -101,8 +101,8 @@ class TestGeometryFileSink(unittest.TestCase):
 
         # compare dataframes without checking the order of records / columns
         assert_frame_equal(actual, self.expected, check_like=True)
-        # compare projections ('init' contains the EPSG code)
-        assert actual.crs["init"] == self.expected.crs["init"]
+        # compare projections
+        assert actual.crs == self.expected.crs
 
     @pytest.mark.skipif(
         "gpkg" not in sinks.GeometryFileSink.supported_extensions,
@@ -118,7 +118,7 @@ class TestGeometryFileSink(unittest.TestCase):
         # compare dataframes without checking the order of records / columns
         assert_frame_equal(actual, self.expected, check_like=True)
         # compare projections ('init' contains the EPSG code)
-        assert actual.crs["init"] == self.expected.crs["init"]
+        assert actual.crs == self.expected.crs
 
     def test_shapefile(self):
         block = self.klass(self.source, self.path, "shp")
@@ -130,7 +130,7 @@ class TestGeometryFileSink(unittest.TestCase):
         # compare dataframes without checking the order of records / columns
         assert_frame_equal(actual, self.expected, check_like=True)
         # compare projections ('init' contains the EPSG code)
-        assert actual.crs["init"] == self.expected.crs["init"]
+        assert actual.crs == self.expected.crs
 
     @pytest.mark.skipif(
         "gml" not in sinks.GeometryFileSink.supported_extensions,
@@ -181,7 +181,7 @@ class TestGeometryFileSink(unittest.TestCase):
         # compare dataframes without checking the order of records / columns
         assert_frame_equal(actual, self.expected_combined, check_like=True)
         # compare projections ('init' contains the EPSG code)
-        assert actual.crs["init"] == self.expected_combined.crs["init"]
+        assert actual.crs == self.expected_combined.crs
 
     def test_merge_files_cleanup(self):
         block = self.klass(self.source, self.path, "geojson")
@@ -209,7 +209,7 @@ class TestGeometryFileSink(unittest.TestCase):
         for filename in os.listdir(self.path):
             df = gpd.read_file(os.path.join(self.path, filename))
             assert len(df) == 1
-            assert df.crs["init"] == "epsg:3857"
+            assert df.crs.to_string() == "EPSG:3857"
 
     def test_to_file_geojson(self):
         self.source.to_file(self.path + ".geojson", **self.request)

--- a/dask_geomodeling/tests/test_geometry_sinks.py
+++ b/dask_geomodeling/tests/test_geometry_sinks.py
@@ -20,7 +20,7 @@ except ImportError:
 
 
 def compare_crs(actual, expected):
-    if utils.GEOPANDAS_0_7_0:
+    if utils.GEOPANDAS_GTE_0_7_0:
         assert actual == expected
     else:
         assert actual["init"] == expected["init"]

--- a/dask_geomodeling/tests/test_geometry_sinks.py
+++ b/dask_geomodeling/tests/test_geometry_sinks.py
@@ -119,7 +119,7 @@ class TestGeometryFileSink(unittest.TestCase):
 
         # compare dataframes without checking the order of records / columns
         assert_frame_equal(actual, self.expected, check_like=True)
-        # compare projections ('init' contains the EPSG code)
+        # compare projections
         assert actual.crs == self.expected.crs
 
     def test_shapefile(self):
@@ -131,7 +131,7 @@ class TestGeometryFileSink(unittest.TestCase):
 
         # compare dataframes without checking the order of records / columns
         assert_frame_equal(actual, self.expected, check_like=True)
-        # compare projections ('init' contains the EPSG code)
+        # compare projections
         assert actual.crs == self.expected.crs
 
     @pytest.mark.skipif(
@@ -150,7 +150,6 @@ class TestGeometryFileSink(unittest.TestCase):
 
         # compare dataframes without checking the order of records / columns
         assert_frame_equal(actual, self.expected, check_like=True)
-        # GML does not contain a CRS
 
     def test_fields_non_available(self):
         with pytest.raises(ValueError):
@@ -182,7 +181,7 @@ class TestGeometryFileSink(unittest.TestCase):
 
         # compare dataframes without checking the order of records / columns
         assert_frame_equal(actual, expected, check_like=True)
-        # compare projections ('init' contains the EPSG code)
+        # compare projections
         assert actual.crs == expected.crs
 
     def test_merge_files_cleanup(self):

--- a/dask_geomodeling/tests/test_utils.py
+++ b/dask_geomodeling/tests/test_utils.py
@@ -14,6 +14,7 @@ import pandas as pd
 import geopandas as gpd
 
 from dask_geomodeling import utils
+import pyproj
 
 
 class TestUtils(unittest.TestCase):
@@ -154,10 +155,12 @@ class TestUtils(unittest.TestCase):
                     f("..\\", "C:\\tmp")
 
     def test_get_crs(self):
+        expected_type = pyproj.CRS if utils.GEOPANDAS_0_7_0 else dict
+
         # from EPSG
         epsg = "EPSG:28992"
         crs = utils.get_crs(epsg)
-        self.assertIsInstance(crs, dict)
+        self.assertIsInstance(crs, expected_type)
 
         # from proj4
         proj4 = """
@@ -167,7 +170,7 @@ class TestUtils(unittest.TestCase):
             +units=m +no_defs
         """
         crs = utils.get_crs(proj4)
-        self.assertIsInstance(crs, dict)
+        self.assertIsInstance(crs, expected_type)
 
     def test_shapely_transform(self):
         src_srs = "EPSG:28992"

--- a/dask_geomodeling/tests/test_utils.py
+++ b/dask_geomodeling/tests/test_utils.py
@@ -154,7 +154,7 @@ class TestUtils(unittest.TestCase):
                     f("..\\", "C:\\tmp")
 
     def test_get_crs(self):
-        if utils.GEOPANDAS_0_7_0:
+        if utils.GEOPANDAS_GTE_0_7_0:
             from pyproj import CRS
             expected_type = CRS
         else:

--- a/dask_geomodeling/tests/test_utils.py
+++ b/dask_geomodeling/tests/test_utils.py
@@ -14,7 +14,6 @@ import pandas as pd
 import geopandas as gpd
 
 from dask_geomodeling import utils
-import pyproj
 
 
 class TestUtils(unittest.TestCase):
@@ -155,7 +154,11 @@ class TestUtils(unittest.TestCase):
                     f("..\\", "C:\\tmp")
 
     def test_get_crs(self):
-        expected_type = pyproj.CRS if utils.GEOPANDAS_0_7_0 else dict
+        if utils.GEOPANDAS_0_7_0:
+            from pyproj import CRS
+            expected_type = CRS
+        else:
+            expected_type = dict
 
         # from EPSG
         epsg = "EPSG:28992"

--- a/dask_geomodeling/utils.py
+++ b/dask_geomodeling/utils.py
@@ -30,8 +30,8 @@ try:
 except ImportError:
     from fiona import drivers as fiona_env  # NOQA
 
-GEOPANDAS_0_7_0 = LooseVersion(geopandas.__version__) >= LooseVersion("0.7.0")
-if GEOPANDAS_0_7_0:
+GEOPANDAS_GTE_0_7_0 = LooseVersion(geopandas.__version__) >= LooseVersion("0.7.0")
+if GEOPANDAS_GTE_0_7_0:
     from pyproj import CRS
 
 
@@ -351,7 +351,7 @@ def get_crs(user_input):
       for geopandas >= 0.7: pyproj.CRS
       for geopandas < 0.7: dict
     """
-    if GEOPANDAS_0_7_0:
+    if GEOPANDAS_GTE_0_7_0:
         return CRS(user_input)
     wkt = osr.GetUserInputAsWKT(str(user_input))
     sr = osr.SpatialReference(wkt)

--- a/dask_geomodeling/utils.py
+++ b/dask_geomodeling/utils.py
@@ -21,7 +21,6 @@ from shapely import wkb as shapely_wkb
 import fiona
 import fiona.crs
 import geopandas
-import pyproj
 
 
 POLYGON = "POLYGON (({0} {1},{2} {1},{2} {3},{0} {3},{0} {1}))"
@@ -32,6 +31,8 @@ except ImportError:
     from fiona import drivers as fiona_env  # NOQA
 
 GEOPANDAS_0_7_0 = LooseVersion(geopandas.__version__) >= LooseVersion("0.7.0")
+if GEOPANDAS_0_7_0:
+    from pyproj import CRS
 
 
 def get_index(values, no_data_value):
@@ -351,7 +352,7 @@ def get_crs(user_input):
       for geopandas < 0.7: dict
     """
     if GEOPANDAS_0_7_0:
-        return pyproj.CRS(user_input)
+        return CRS(user_input)
     wkt = osr.GetUserInputAsWKT(str(user_input))
     sr = osr.SpatialReference(wkt)
     key = str("GEOGCS") if sr.IsGeographic() else str("PROJCS")

--- a/dask_geomodeling/utils.py
+++ b/dask_geomodeling/utils.py
@@ -18,6 +18,7 @@ from shapely.geometry import box, Point
 from shapely import wkb as shapely_wkb
 
 import fiona
+import fiona.crs
 
 POLYGON = "POLYGON (({0} {1},{2} {1},{2} {3},{0} {3},{0} {1}))"
 
@@ -353,9 +354,20 @@ def get_crs(user_input):
 def crs_to_srs(crs):
     """
     Recover our own WKT definition of projections from a fiona CRS
+
+    Args:
+      crs (pyproj.CRS or dict): what is returned from GeoDataFrame().crs
+
+    Returns:
+      string: a "EPSG:xxx" or WKT representation of the crs.
     """
-    proj4_str = fiona.crs.to_string(crs)
-    return get_epsg_or_wkt(proj4_str)
+    if crs is None:
+        return
+    elif isinstance(crs, dict):  # geopandas < 0.7
+        proj4_str = fiona.crs.to_string(crs)
+        return get_epsg_or_wkt(proj4_str)
+    else:  # geopandas >= 0.7
+        return crs.to_string()
 
 
 def wkb_transform(wkb, src_sr, dst_sr):

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -20,13 +20,12 @@ Anaconda (all platforms)
 2. Start the `Anaconda Prompt` via the start menu
 3. ``conda config --add channels conda-forge``
 4. ``conda update conda``
-5. ``conda install python=3.6 gdal=2.4.1 scipy=1.3.1 geopandas=0.6 dask-geomodeling ipyleaflet matplotlib pillow``
+5. ``conda install python=3.6 gdal=2.4.1 scipy=1.3.1 dask-geomodeling ipyleaflet matplotlib pillow``
 
 .. note::
 
    The version pins of python, gdal and scipy are related to issues specific
-   to Windows. On other platforms you may leave them out. The version pin of
-   geopandas is due to a known version incompatibility of dask-geomodeling.
+   to Windows. On other platforms you may leave them out. 
    If you need other python or GDAL versions
    on windows: while `dask-geomodeling` itself is compatible with all current
    versions, you may may have a hard time getting it to work via Anaconda and

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ install_requires = (
         "dask[delayed]>=0.18",
         "pandas>=0.19",
         "geopandas>=0.4",
+        "pyproj>=2",
         "pytz",
         "numpy>=1.12",
         "scipy>=0.19",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ install_requires = (
         "dask[delayed]>=0.18",
         "pandas>=0.19",
         "geopandas>=0.4",
-        "pyproj>=2",
         "pytz",
         "numpy>=1.12",
         "scipy>=0.19",


### PR DESCRIPTION
This fixes #38 and #39

geopandas 0.7 changed the the `crs` from a dictionary to a `pyproj.CRS` object. Because I don't want to drop compatibility with geopandas 0.5 yet, I added some conditionals to `utils.get_crs` and `utils.srs_to_crs`.

Also, the new RFC for GeoJSON specifies explicitely that a `"crs"` should not be included. Instead, coordinates should be represented in WGS84.


