### PR TITLE
Check for matching time resolutions in rasters.Clip

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog of dask-geomodeling
 2.2.11 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Check for matching time resolutions in raster.Clip.
 
 
 2.2.10 (2020-07-29)

--- a/dask_geomodeling/raster/misc.py
+++ b/dask_geomodeling/raster/misc.py
@@ -39,7 +39,7 @@ class Clip(BaseSingle):
 
     If the 'source' raster is a boolean raster, False will result in 'no data'.
 
-    Note that both input rasters are required to have the same time resolution.
+    Note that the input rasters are required to have the same time resolution.
 
     Args:
       store (RasterBlock): Raster whose values are clipped

--- a/dask_geomodeling/raster/misc.py
+++ b/dask_geomodeling/raster/misc.py
@@ -64,6 +64,20 @@ class Clip(BaseSingle):
     def source(self):
         return self.args[1]
 
+    def get_sources_and_requests(self, **request):
+        start = request.get("start", None)
+        stop = request.get("stop", None)
+
+        if start is not None and stop is not None:
+            # limit request to self.period so that resulting data is aligned
+            period = self.period
+            if period is not None:
+                request["start"] = max(start, period[0])
+                request["stop"] = min(stop, period[1])
+
+        return ((source, request) for source in self.args)
+
+
     @staticmethod
     def process(data, source_data):
         """ Mask store_data where source_data has no data """
@@ -122,6 +136,21 @@ class Clip(BaseSingle):
         if result.GetArea() == 0.0:
             return
         return result
+
+    @property
+    def period(self):
+        """ Return period datetime tuple. """
+        periods = [x.period for x in self.args]
+        if any(period is None for period in periods):
+            return None  # None precedes
+
+        # multiple periods: return the overlapping period
+        start = max([p[0] for p in periods])
+        stop = min([p[1] for p in periods])
+        if stop < start:
+            return None  # no overlap
+        else:
+            return start, stop
 
 
 class Mask(BaseSingle):

--- a/dask_geomodeling/raster/misc.py
+++ b/dask_geomodeling/raster/misc.py
@@ -39,6 +39,8 @@ class Clip(BaseSingle):
 
     If the 'source' raster is a boolean raster, False will result in 'no data'.
 
+    Note that both input rasters are required to have the same time resolution.
+
     Args:
       store (RasterBlock): Raster whose values are clipped
       source (RasterBlock): Raster that is used as the clipping mask
@@ -51,7 +53,7 @@ class Clip(BaseSingle):
         if not isinstance(source, RasterBlock):
             raise TypeError("'{}' object is not allowed".format(type(store)))
         # assert that timedeltas are equal (if self.store is temporal)
-        if store.timedelta is not None and store.timedelta != source.timedelta:
+        if store.timedelta != source.timedelta:
             raise ValueError(
                 "Time resolution of the clipping mask does not match that of "
                 "the values raster. Consider using Snap."

--- a/dask_geomodeling/raster/misc.py
+++ b/dask_geomodeling/raster/misc.py
@@ -52,7 +52,7 @@ class Clip(BaseSingle):
     def __init__(self, store, source):
         if not isinstance(source, RasterBlock):
             raise TypeError("'{}' object is not allowed".format(type(store)))
-        # assert that timedeltas are equal (if self.store is temporal)
+        # timedeltas are required to be equal
         if store.timedelta != source.timedelta:
             raise ValueError(
                 "Time resolution of the clipping mask does not match that of "

--- a/dask_geomodeling/raster/misc.py
+++ b/dask_geomodeling/raster/misc.py
@@ -50,6 +50,12 @@ class Clip(BaseSingle):
     def __init__(self, store, source):
         if not isinstance(source, RasterBlock):
             raise TypeError("'{}' object is not allowed".format(type(store)))
+        # assert that timedeltas are equal (if self.store is temporal)
+        if store.timedelta is not None and store.timedelta != source.timedelta:
+            raise ValueError(
+                "Time resolution of the clipping mask does not match that of "
+                "the values raster. Consider using Snap."
+            )
         super(Clip, self).__init__(store, source)
 
     @property

--- a/dask_geomodeling/raster/misc.py
+++ b/dask_geomodeling/raster/misc.py
@@ -77,7 +77,6 @@ class Clip(BaseSingle):
 
         return ((source, request) for source in self.args)
 
-
     @staticmethod
     def process(data, source_data):
         """ Mask store_data where source_data has no data """

--- a/dask_geomodeling/tests/test_raster_misc.py
+++ b/dask_geomodeling/tests/test_raster_misc.py
@@ -82,7 +82,7 @@ def test_clip_attrs_no_intersection(source):
 def test_clip_matching_timedelta(source):
     clip = raster.Clip(source, source == 7)
     assert clip.timedelta == source.timedelta
-    
+
 
 def test_clip_unequal_timedelta(source, empty_source):
     # clip checks for matching timedeltas; test that here
@@ -133,7 +133,7 @@ def test_clip_time_request(source, vals_request, expected_time):
 
 
 def test_clip_partial_temporal_overlap(source, vals_request):
-     # create a clipping mask in that temporally does not overlap the store
+    # create a clipping mask in that temporally does not overlap the store
     clipping_mask = MemorySource(
         data=source.data,
         no_data_value=source.no_data_value,
@@ -149,7 +149,7 @@ def test_clip_partial_temporal_overlap(source, vals_request):
 
 
 def test_clip_no_temporal_overlap(source, vals_request):
-     # create a clipping mask in that temporally does not overlap the store
+    # create a clipping mask in that temporally does not overlap the store
     clipping_mask = MemorySource(
         data=source.data,
         no_data_value=source.no_data_value,

--- a/dask_geomodeling/tests/test_raster_misc.py
+++ b/dask_geomodeling/tests/test_raster_misc.py
@@ -132,6 +132,38 @@ def test_clip_time_request(source, vals_request, expected_time):
     assert clip.get_data(**vals_request)["time"] == expected_time
 
 
+def test_clip_partial_temporal_overlap(source, vals_request):
+     # create a clipping mask in that temporally does not overlap the store
+    clipping_mask = MemorySource(
+        data=source.data,
+        no_data_value=source.no_data_value,
+        projection=source.projection,
+        pixel_size=source.pixel_size,
+        pixel_origin=source.pixel_origin,
+        time_first=source.time_first + source.time_delta,
+        time_delta=source.time_delta,
+    )
+    clip = raster.Clip(source, clipping_mask)
+    assert clip.period == (clipping_mask.period[0], source.period[1])
+    assert clip.get_data(**vals_request)["values"][:, 0, 0].tolist() == [7, 255]
+
+
+def test_clip_no_temporal_overlap(source, vals_request):
+     # create a clipping mask in that temporally does not overlap the store
+    clipping_mask = MemorySource(
+        data=source.data,
+        no_data_value=source.no_data_value,
+        projection=source.projection,
+        pixel_size=source.pixel_size,
+        pixel_origin=source.pixel_origin,
+        time_first=source.time_first + 10 * source.time_delta,
+        time_delta=source.time_delta,
+    )
+    clip = raster.Clip(source, clipping_mask)
+    assert clip.period == None
+    assert clip.get_data(**vals_request) is None
+
+
 def test_reclassify(source, vals_request):
     view = raster.Reclassify(store=source, data=[[7, 1000]])
     data = view.get_data(**vals_request)


### PR DESCRIPTION
Closes https://github.com/nens/lizard-nxt/issues/3646

Using `raster.Clip` does not work if the clipping mask is non-temporal while the values raster is temporal. There is a workaround: use `raster.Snap`. This adds a check so that users cannot make this mistake anymore.