### PR TITLE
Fix point requests in RasterizeWKT

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog of dask-geomodeling
 2.2.12 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fixed point requests for RasterizeWKT.
 
 
 2.2.11 (2020-09-01)


### PR DESCRIPTION
Sometimes, ```geometry.intersects(box(x, y, x, y))``` gives different results than ```geometry.intersects(Point(x, y))``.

This is because the box is invalid.