### PR TITLE
ParseTextColumn does not return categorical anymore

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Changelog of dask-geomodeling
   ClassifyFromColumns. This leads to pandas incompatibilities with later
   operations (round, subtract, where, mask).
 
+- Never return Categorical dtypes from ParseTextColumn. (#79)
+
 
 2.3.0 (2020-10-09)
 ------------------

--- a/dask_geomodeling/geometry/text.py
+++ b/dask_geomodeling/geometry/text.py
@@ -114,7 +114,7 @@ class ParseTextColumn(BaseSingle):
         except KeyError:
             extra_columns_aligned = pd.DataFrame([], columns=key_mapping.values())
 
-        # Assign the extra columns one by one. This preserves categoricals.
+        # Assign the extra columns to the original dataframe.
         for name in extra_columns_aligned.columns:
             if extra_columns_aligned[name].isnull().all():
                 f[name] = np.nan

--- a/dask_geomodeling/tests/test_geometry.py
+++ b/dask_geomodeling/tests/test_geometry.py
@@ -1963,7 +1963,7 @@ class TestText(unittest.TestCase):
         )
         view = text.ParseTextColumn(source, "description", self.key_mapping)
         data = view.get_data(**self.request)["features"]
-        self.assertEqual("category", str(data["model_name"].dtype))
+        self.assertEqual("object", str(data["model_name"].dtype))
         for col in self.expected:
             assert data.loc[1, col] == self.expected[col]
             assert data.loc[2, col] == self.expected[col]
@@ -2017,7 +2017,7 @@ class TestText(unittest.TestCase):
             self.source, "description", {"modelname": "description"}
         )
         data = view.get_data(**self.request)["features"]
-        self.assertEqual("category", str(data["description"].dtype))
+        self.assertEqual("object", str(data["description"].dtype))
         assert data.loc[1, "description"] == "rotterdam 01"
 
     def test_parser_into_same_column_non_existing(self):


### PR DESCRIPTION
I found another geoblock that returned categorical-dtype columns. Not anymore!