### PR TITLE
[Done] Fix Classify still returns categorical in some cases

### DIFF
--- a/dask_geomodeling/geometry/field_operations.py
+++ b/dask_geomodeling/geometry/field_operations.py
@@ -61,7 +61,8 @@ class Classify(BaseSingleSeries):
       labels (list): The classification returned if a value falls in a specific
         bin (i.e. ``["A", "B", "C"]``). The length of this list is either one
         larger or one less than the length of the ``bins`` argument. Labels
-        should be unique.
+        should be unique. If labels are numeric, they are always
+        converted to float to be able to deal with NaN values.
       right (boolean, optional): Determines what side of the intervals are
         closed. Defaults to True (the right side of the bin is closed so a
         value assigned to the bin on the left if it is exactly on a bin edge).
@@ -112,8 +113,11 @@ class Classify(BaseSingleSeries):
         if series.dtype == object:
             series = series.fillna(value=np.nan)
         result = pd.cut(series, bins, right, labels)
-        # transform from categorical to whatever suits the "labels"
-        result = pd.Series(result, dtype=pd.Series(labels).dtype)
+
+        # Transform from categorical to whatever suits the "labels". The
+        # dtype has to be able to accomodate NaN as well.
+        result = result.astype(pd.Series(labels + [np.nan]).dtype)
+
         if open_bounds:
             # patch the result, we actually want to classify np.inf
             if right:
@@ -142,7 +146,8 @@ class ClassifyFromColumns(SeriesBlock):
       labels (list): The classification returned if a value falls in a specific
         bin (i.e. ``["A", "B", "C"]``). The length of this list is either one
         larger or one less than the length of the ``bins`` argument. Labels
-        should be unique.
+        should be unique. If labels are numeric, they are always
+        converted to float to be able to deal with NaN values.
       right (boolean, optional): Determines what side of the intervals are
         closed. Defaults to True (the right side of the bin is closed so a
         value assigned to the bin on the left if it is exactly on a bin edge).


### PR DESCRIPTION
This fixes field_operations.Classify if used with int-typed labels. A NaN value in the result resulted in a Categorical output dtype. This gives issues with subsequent mathematical operations for pandas 1.* (see #74 

To fix this, Classify now returns floats when input labels are integers.