### PR TITLE
Revert changes to elemwise.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog of dask-geomodeling
 2.3.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Reverted changes to elemwise.
 
 
 2.3.5 (2022-02-02)

--- a/dask_geomodeling/raster/elemwise.py
+++ b/dask_geomodeling/raster/elemwise.py
@@ -55,26 +55,17 @@ class BaseElementwise(RasterBlock):
         return [arg for arg in self.args if isinstance(arg, RasterBlock)]
 
     def get_sources_and_requests(self, **request):
-
-        period = self.period
-        process_kwargs = {
-            "dtype": self.dtype.name, "fillvalue": self.fillvalue,
-        }
-        if period is None:
-            return [(process_kwargs, None)]
-
-        # limit request to self.period so that resulting data is aligned
         start = request.get("start", None)
         stop = request.get("stop", None)
-        if start is not None:
-            if stop is not None:
+
+        if start is not None and stop is not None:
+            # limit request to self.period so that resulting data is aligned
+            period = self.period
+            if period is not None:
                 request["start"] = max(start, period[0])
                 request["stop"] = min(stop, period[1])
-            else:  # stop is None but start isn't
-                request["start"] = min(max(start, period[0]), period[1])
-        else:  # start and stop are both None
-            request["start"] = period[1]
 
+        process_kwargs = {"dtype": self.dtype.name, "fillvalue": self.fillvalue}
         sources_and_requests = [(source, request) for source in self.args]
 
         return [(process_kwargs, None)] + sources_and_requests


### PR DESCRIPTION
It turned out existing graphs rely on the loose temporal enforcement of source periods (it kinda acts like a snap block now and that is misused in waterlevel calculation in the damage estimator and (worse) also saved to the corresponding scenario result rasters ("dmge-depth"). Now the new Max may be stricter than needed, but I think it is easier to become more permissive later than the other way around...