### PR TITLE
Basten propagate time resolution fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog of dask-geomodeling
 2.3.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed proper propagation of time resolution through AggregateRaster
 
 
 2.3.7 (2022-02-08)

--- a/dask_geomodeling/geometry/aggregate.py
+++ b/dask_geomodeling/geometry/aggregate.py
@@ -320,6 +320,7 @@ class AggregateRaster(GeometryBlock):
             "bbox": (x1, y1, x2, y2),
             "width": width,
             "height": height,
+            "time_resolution": request.get("time_resolution"),
         }
 
         process_kwargs = {

--- a/dask_geomodeling/geometry/aggregate.py
+++ b/dask_geomodeling/geometry/aggregate.py
@@ -319,9 +319,12 @@ class AggregateRaster(GeometryBlock):
             "aggregation": None,  # TODO
             "bbox": (x1, y1, x2, y2),
             "width": width,
-            "height": height,
-            "time_resolution": request.get("time_resolution"),
+            "height": height
         }
+
+        # only propagate if provided
+        if "time_resolution" in request:
+            raster_request["time_resolution"] = request.get("time_resolution")
 
         process_kwargs = {
             "mode": request.get("mode", "intersects"),

--- a/dask_geomodeling/geometry/aggregate.py
+++ b/dask_geomodeling/geometry/aggregate.py
@@ -324,7 +324,7 @@ class AggregateRaster(GeometryBlock):
 
         # only propagate if provided
         if "time_resolution" in request:
-            raster_request["time_resolution"] = request.get("time_resolution")
+            raster_request["time_resolution"] = request["time_resolution"]
 
         process_kwargs = {
             "mode": request.get("mode", "intersects"),

--- a/dask_geomodeling/tests/test_geometry.py
+++ b/dask_geomodeling/tests/test_geometry.py
@@ -817,6 +817,35 @@ class TestAggregateRaster(unittest.TestCase):
             self.assertEqual(6, request["width"])
             self.assertEqual(6, request["height"])
 
+    def test_raster_time_resolution(self):
+        req = self.request
+        req["time_resolution"] = 3600000
+        req["geometry"] = box(0, 0, 10, 10)
+        
+        # temp_group = GroupTemporal([
+        #     MockRaster(timedelta=Timedelta(hours=1)),
+        #     MockRaster(timedelta=Timedelta(minutes=1)), 
+        #     MockRaster(timedelta=Timedelta(seconds=1))
+        # ])
+
+        temp_raster = MockRaster(
+            origin=Datetime(2018, 1, 1),
+            timedelta=Timedelta(hours=1),
+            bands=1
+        )
+
+        geom_source = MockGeometry(
+            polygons=[((2.0, 2.0), (8.0, 2.0), (8.0, 8.0), (2.0, 8.0))],
+            properties=[{"id": 1}],
+        )
+        view = geometry.AggregateRaster(
+            source=geom_source, raster=temp_raster, statistic="sum"
+        )
+
+        _, (source, request), _ = view.get_sources_and_requests(**req)
+
+        self.assertEqual(3600000, request["time_resolution"])
+
     def test_pixel_size(self):
         # larger
         self.view = geometry.AggregateRaster(

--- a/dask_geomodeling/tests/test_raster.py
+++ b/dask_geomodeling/tests/test_raster.py
@@ -1158,6 +1158,11 @@ class TestTemporalAggregate(unittest.TestCase):
             **self.request,
         }
 
+    def test_request(self):
+        view = self.klass(self.raster, frequency="D", statistic="sum")
+        (req, _), _, _ = view.get_sources_and_requests(**self.request_all)
+        self.assertEqual(req["frequency"], "D")
+
     def test_period_day_agg(self):
         self.assertEqual(
             (Datetime(2000, 1, 1), Datetime(2000, 1, 3)),

--- a/dask_geomodeling/tests/test_raster.py
+++ b/dask_geomodeling/tests/test_raster.py
@@ -1158,11 +1158,6 @@ class TestTemporalAggregate(unittest.TestCase):
             **self.request,
         }
 
-    def test_request(self):
-        view = self.klass(self.raster, frequency="D", statistic="sum")
-        (req, _), _, _ = view.get_sources_and_requests(**self.request_all)
-        self.assertEqual(req["frequency"], "D")
-
     def test_period_day_agg(self):
         self.assertEqual(
             (Datetime(2000, 1, 1), Datetime(2000, 1, 3)),

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -117,3 +117,16 @@ Install dask-geomodeling::
 Run the tests::
 
     (.venv) $ pytest
+
+Advanced: Running tests in VSCode for WSL2 (Ubuntu)
+-----------------------------------
+
+It is possible to run the tests (that reside in WSL2) but perform debugging in VSCode (Windows)
+
+1 Install the Python extension in VSCode.
+
+2 Open the ``Test Explorer View`` (beaker icon)
+
+3 Press the ``Configure Tests`` button. Select ``pytest`` as test framework, and base the configuration on the existing ``setup.cfg``
+
+4 The tests should now be discovered, and by pressing the ``Debug Tests`` button, it is now possible to place breakpoints and step through the tests. 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -119,7 +119,7 @@ Run the tests::
     (.venv) $ pytest
 
 Advanced: Running tests in VSCode for WSL2 (Ubuntu)
------------------------------------
+-------------------------------------------------------
 
 It is possible to run the tests (that reside in WSL2) but perform debugging in VSCode (Windows)
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -129,4 +129,7 @@ It is possible to run the tests (that reside in WSL2) but perform debugging in V
 
 3 Press the ``Configure Tests`` button. Select ``pytest`` as test framework, and base the configuration on the existing ``setup.cfg``
 
-4 The tests should now be discovered, and by pressing the ``Debug Tests`` button, it is now possible to place breakpoints and step through the tests. 
+4 The tests should now be discovered, and by pressing the ``Debug Tests`` button, it is now possible to place breakpoints and step through the tests.
+
+A known `issue <https://stackoverflow.com/questions/58799879/vscode-on-discover-tests-error-spawn-python-enoent>`_ can be found on StackOverflow.
+

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -131,5 +131,7 @@ It is possible to run the tests (that reside in WSL2) but perform debugging in V
 
 4 The tests should now be discovered, and by pressing the ``Debug Tests`` button, it is now possible to place breakpoints and step through the tests.
 
+See the `VSCode manual for python testing <https://code.visualstudio.com/docs/python/testing>`_ for explanation regarding running the tests.
+
 A known `issue <https://stackoverflow.com/questions/58799879/vscode-on-discover-tests-error-spawn-python-enoent>`_ can be found on StackOverflow.
 


### PR DESCRIPTION
AggregateRaster block now passes time_resolution to request. 

Added some trivial tests to check whether for TemporalAggregate and AggregateRaster properly pass frequency / time_resolution.

