### PR TITLE
Improve AggregateRaster for small source geometries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog of dask-geomodeling
 2.3.13 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Improved AggregateRaster for small source geometries.
 
 
 2.3.12 (2022-11-28)

--- a/dask_geomodeling/geometry/aggregate.py
+++ b/dask_geomodeling/geometry/aggregate.py
@@ -301,11 +301,10 @@ class AggregateRaster(GeometryBlock):
                 "the maximum ({} > {})".format(required_pixels, max_pixels)
             )
 
-        # snap the extent to (0, 0) to prevent subpixel shifts
-        x1 = floor(x1 / pixel_size) * pixel_size
-        y1 = floor(y1 / pixel_size) * pixel_size
-        x2 = ceil(x2 / pixel_size) * pixel_size
-        y2 = ceil(y2 / pixel_size) * pixel_size
+        # consider (x1, y2) as the origin of a grid of size pixel_size.
+        # snap x2 and y1 to the grid. the new bbox contains the old.
+        x2 = x1 + ceil((x2 - x1) / pixel_size) * pixel_size
+        y1 = y2 - ceil((y2 - y1) / pixel_size) * pixel_size
 
         # compute the width and height
         width = max(int((x2 - x1) / pixel_size), 1)

--- a/dask_geomodeling/geometry/aggregate.py
+++ b/dask_geomodeling/geometry/aggregate.py
@@ -307,8 +307,8 @@ class AggregateRaster(GeometryBlock):
         y1 = y2 - ceil((y2 - y1) / pixel_size) * pixel_size
 
         # compute the width and height
-        width = max(int((x2 - x1) / pixel_size), 1)
-        height = max(int((y2 - y1) / pixel_size), 1)
+        width = max(round((x2 - x1) / pixel_size), 1)
+        height = max(round((y2 - y1) / pixel_size), 1)
 
         raster_request = {
             "mode": "vals",


### PR DESCRIPTION
This pull request solves https://github.com/nens/lizard-nxt/issues/5814 by using a different strategy in AggregateRaster.

An alternative solution is to enable the `ALL_TOUCHED` rasterization option in GDAL (affecting other calculations too): https://gdal.org/programs/gdal_rasterize.html#cmdoption-gdal_rasterize-at.