### PR TITLE
Verkerk fix group

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog of dask-geomodeling
 2.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Made raster.combine.Group behave like a single raster source if its sources
+have an aligned timestructure, even when parts of the group's period are not
+covered by any of the source's periods.
 
 
 2.8.0 (2026-04-21)

--- a/dask_geomodeling/raster/combine.py
+++ b/dask_geomodeling/raster/combine.py
@@ -201,9 +201,7 @@ class Group(BaseCombine):
 
         # plan for merging
         timedelta = self.timedelta
-        mixed_time = timedelta is None or start is None
-
-        if mixed_time:  # merge by time
+        if timedelta is None:  # merge by time
             sources = self.get_relevant_sources(start, stop)
             if not sources:
                 # with mixed time, no source means no result
@@ -229,7 +227,9 @@ class Group(BaseCombine):
             td_sec = timedelta.total_seconds()
             period = self.period
             origin = period[0]
-            if start <= period[0]:
+            if start is None:
+                start = period[1]
+            elif start <= period[0]:
                 start = period[0]
             else:
                 # ceil start to the closest integer timedelta

--- a/dask_geomodeling/raster/combine.py
+++ b/dask_geomodeling/raster/combine.py
@@ -161,14 +161,14 @@ class Group(BaseCombine):
       RasterBlock that combines all input rasters
     """
 
-    def get_stores(self, start, stop):
-        """ Return all relevant stores for given start and stop. """
+    def get_relevant_sources(self, start, stop):
+        """ Return all relevant sources for given start and stop. """
         # check stores and select those stores that contain data
         stores = [s for s in self.args if s.period is not None]
 
         # there could be no store with data at all
         if not stores:
-            return stores
+            return []
 
         # convenience
         starts, stops = zip(*(s.period for s in stores))
@@ -190,7 +190,7 @@ class Group(BaseCombine):
             zipped = zip(stops + starts, stores + stores)
             return [s for d, s in zipped if d == closest]
 
-        # start and stop given, return all relevant stores
+        # start and stop given, return all intersecting stores
         zipped = zip(starts, stops, stores)
         return [s for a, b, s in zipped if not (stop < a or start > b)]
 
@@ -199,17 +199,15 @@ class Group(BaseCombine):
         stop = request.get("stop", None)
         mode = request["mode"]
 
-        sources = self.get_stores(start, stop)
-
-        # just pass on the source and request if we have no source
-        if not sources:
-            return [(dict(combine_mode="simple"), None)]
-
         # plan for merging
-        timedelta = self.get_aligned_timedelta(sources)
-        mixed_time = timedelta is None or start is None or stop is None
+        timedelta = self.timedelta
+        mixed_time = timedelta is None or start is None
 
         if mixed_time:  # merge by time
+            sources = self.get_relevant_sources(start, stop)
+            if not sources:
+                # with mixed time, no source means no result
+                return [(dict(combine_mode="simple"), None)]
             requests = []
             time_requests = []
             for source in sources:
@@ -230,8 +228,7 @@ class Group(BaseCombine):
         else:  # merge by bands
             td_sec = timedelta.total_seconds()
             period = self.period
-            origin = sources[0].period[0]  # any will do; they are aligned
-
+            origin = period[0]
             if start <= period[0]:
                 start = period[0]
             else:
@@ -239,7 +236,9 @@ class Group(BaseCombine):
                 start_delta = (origin - start).total_seconds() % td_sec
                 start += Timedelta(seconds=start_delta)
 
-            if stop >= period[1]:
+            if stop is None:
+                stop = start
+            elif stop >= period[1]:
                 stop = period[1]
             else:
                 # floor stop to the closest integer timedelta
@@ -260,6 +259,7 @@ class Group(BaseCombine):
                     )
                 ]
 
+            sources = self.get_relevant_sources(start, stop)
             requests = []
             bands = []
             for source in sources:
@@ -273,18 +273,18 @@ class Group(BaseCombine):
                 this_request = request.copy()
                 this_request.update(start=this_start, stop=this_stop)
                 requests.append((source, this_request))
-
             process_kwargs = dict(
                 combine_mode="by_bands",
                 mode=mode,
                 bands=bands,
-                last_band=int((stop - start).total_seconds() // td_sec) + 1,
             )
-
-        # in case of a 'vals' request, keep track of the dtype
+            nbands = int((stop - start).total_seconds() // td_sec) + 1
+            if mode == "meta":
+                process_kwargs["nbands"] = nbands
+            if mode == "vals":
+                process_kwargs["shape"] = nbands, request["height"], request["width"]
         if mode == "vals":
             process_kwargs["dtype"] = self.dtype
-
         return [(process_kwargs, None)] + requests
 
     @staticmethod
@@ -361,14 +361,12 @@ class Group(BaseCombine):
         return {"meta": meta_result}
 
     @staticmethod
-    def _merge_vals_by_bands(multi, bands, dtype, last_band):
+    def _merge_vals_by_bands(multi, bands, dtype, shape):
         """ Merge chunks using slices. """
         # analyze band structure
-        starts, stops = zip(*bands)
         fillvalue = get_dtype_max(dtype)
 
         # initialize values array
-        shape = (last_band,) + multi[0]["values"].shape[1:]
         values = np.full(shape, fillvalue, dtype=dtype)
 
         # populate values array
@@ -382,13 +380,10 @@ class Group(BaseCombine):
         return {"values": values, "no_data_value": fillvalue}
 
     @staticmethod
-    def _merge_meta_by_bands(multi, bands, last_band):
+    def _merge_meta_by_bands(multi, bands, nbands):
         """ Merge metadata by bands. """
-        # analyze band structure
-        starts, stops = zip(*bands)
-
         # initialize metadata list
-        meta_result = [""] * last_band
+        meta_result = [""] * nbands
 
         # populate metadata list
         for data, (a, b) in zip(multi, bands):
@@ -404,7 +399,6 @@ class Group(BaseCombine):
         # plan for merging
         combine_mode = process_kwargs["combine_mode"]
         mode = process_kwargs.get("mode", None)
-
         if combine_mode == "simple":
             return None
         elif combine_mode == "by_time" and mode == "time":
@@ -447,16 +441,14 @@ class Group(BaseCombine):
                 multi.append(data)
                 bands.append(_bands)
 
-            if len(multi) == 0:
-                return None
-
-            last_band = process_kwargs["last_band"]
             if mode == "vals":
                 dtype = process_kwargs["dtype"]
+                shape = process_kwargs["shape"]
                 return Group._merge_vals_by_bands(
-                    multi=multi, bands=bands, dtype=dtype, last_band=last_band)
+                    multi=multi, bands=bands, dtype=dtype, shape=shape)
             elif mode == "meta":
+                nbands = process_kwargs["nbands"]
                 return Group._merge_meta_by_bands(
-                    multi=multi, bands=bands, last_band=last_band)
+                    multi=multi, bands=bands, nbands=nbands)
         else:
             raise ValueError("Unknown combine_mode / mode combination")

--- a/dask_geomodeling/raster/combine.py
+++ b/dask_geomodeling/raster/combine.py
@@ -62,7 +62,7 @@ class BaseCombine(RasterBlock):
     def timedelta(self):
         """ The period between timesteps in case of equidistant time. """
         return self.get_aligned_timedelta(self.args)
-    
+
     @property
     def temporal(self):
         return any(x.temporal for x in self.args)
@@ -201,10 +201,9 @@ class Group(BaseCombine):
 
         sources = self.get_stores(start, stop)
 
-        # just pass on the source and request if we only have one (or none)
-        if len(sources) <= 1:
-            requests = [(s, request) for s in sources]
-            return [(dict(combine_mode="simple"), None)] + requests
+        # just pass on the source and request if we have no source
+        if not sources:
+            return [(dict(combine_mode="simple"), None)]
 
         # plan for merging
         timedelta = self.get_aligned_timedelta(sources)
@@ -275,7 +274,12 @@ class Group(BaseCombine):
                 this_request.update(start=this_start, stop=this_stop)
                 requests.append((source, this_request))
 
-            process_kwargs = dict(combine_mode="by_bands", mode=mode, bands=bands)
+            process_kwargs = dict(
+                combine_mode="by_bands",
+                mode=mode,
+                bands=bands,
+                last_band=int((stop - start).total_seconds() // td_sec) + 1,
+            )
 
         # in case of a 'vals' request, keep track of the dtype
         if mode == "vals":
@@ -357,14 +361,14 @@ class Group(BaseCombine):
         return {"meta": meta_result}
 
     @staticmethod
-    def _merge_vals_by_bands(multi, bands, dtype):
+    def _merge_vals_by_bands(multi, bands, dtype, last_band):
         """ Merge chunks using slices. """
         # analyze band structure
         starts, stops = zip(*bands)
         fillvalue = get_dtype_max(dtype)
 
         # initialize values array
-        shape = (max(stops),) + multi[0]["values"].shape[1:]
+        shape = (last_band,) + multi[0]["values"].shape[1:]
         values = np.full(shape, fillvalue, dtype=dtype)
 
         # populate values array
@@ -378,13 +382,13 @@ class Group(BaseCombine):
         return {"values": values, "no_data_value": fillvalue}
 
     @staticmethod
-    def _merge_meta_by_bands(multi, bands):
+    def _merge_meta_by_bands(multi, bands, last_band):
         """ Merge metadata by bands. """
         # analyze band structure
         starts, stops = zip(*bands)
 
         # initialize metadata list
-        meta_result = [""] * max(stops)
+        meta_result = [""] * last_band
 
         # populate metadata list
         for data, (a, b) in zip(multi, bands):
@@ -396,16 +400,13 @@ class Group(BaseCombine):
 
     @staticmethod
     def process(process_kwargs, *args):
+
         # plan for merging
         combine_mode = process_kwargs["combine_mode"]
         mode = process_kwargs.get("mode", None)
 
         if combine_mode == "simple":
-            # simple mode, return the result right away
-            if len(args) == 0:
-                return None
-            else:
-                return args[0]
+            return None
         elif combine_mode == "by_time" and mode == "time":
             sorted_times = Group._unique_times(args)
 
@@ -449,10 +450,13 @@ class Group(BaseCombine):
             if len(multi) == 0:
                 return None
 
+            last_band = process_kwargs["last_band"]
             if mode == "vals":
                 dtype = process_kwargs["dtype"]
-                return Group._merge_vals_by_bands(multi, bands, dtype)
+                return Group._merge_vals_by_bands(
+                    multi=multi, bands=bands, dtype=dtype, last_band=last_band)
             elif mode == "meta":
-                return Group._merge_meta_by_bands(multi, bands)
+                return Group._merge_meta_by_bands(
+                    multi=multi, bands=bands, last_band=last_band)
         else:
             raise ValueError("Unknown combine_mode / mode combination")

--- a/dask_geomodeling/tests/test_raster.py
+++ b/dask_geomodeling/tests/test_raster.py
@@ -1047,7 +1047,7 @@ class TestGroup(TestCombine, unittest.TestCase):
         self.assertEqual(meta, ["", "Testmeta for band 0"])
 
         data = view.get_data(mode="vals", width=1, height=1, **request)
-        self.assertEqual(data["values"].tolist(), [[[255]], [[1]]])
+        self.assertEqual(data["values"].tolist(), [[[view.fillvalue]], [[1]]])
 
     def test_stop_in_gap(self):
         view = self.klass(self.storage1, self.storage6)
@@ -1065,25 +1065,42 @@ class TestGroup(TestCombine, unittest.TestCase):
         self.assertEqual(meta, ["Testmeta for band 2", ""])
 
         data = view.get_data(mode="vals", width=1, height=1, **request)
-        self.assertEqual(data["values"].tolist(), [[[1]], [[255]]])
+        self.assertEqual(data["values"].tolist(), [[[1]], [[view.fillvalue]]])
 
-    # def test_only_gap(self):
-        # view = self.klass(self.storage1, self.storage6)
-        # request = dict(
-            # start=Datetime(2000, 1, 1, 0, 15),  # the gap
-            # stop=Datetime(2000, 1, 1, 0, 15),  # also the gap
-        # )
-        # _requests = view.get_sources_and_requests(mode="meta", **request)
-        # self.assertEqual(_requests[0][0]["combine_mode"], "by_bands")
+    def test_only_gap(self):
+        view = self.klass(self.storage1, self.storage6)
+        request = dict(
+            start=Datetime(2000, 1, 1, 0, 15),  # the gap
+            stop=Datetime(2000, 1, 1, 0, 15),  # also the gap
+        )
+        _requests = view.get_sources_and_requests(mode="meta", **request)
+        self.assertEqual(_requests[0][0]["combine_mode"], "by_bands")
 
-        # time = view.get_data(mode="time", **request)["time"]
-        # self.assertEqual(time, [Datetime(2000, 1, 1, 0, 15)])
+        time = view.get_data(mode="time", **request)["time"]
+        self.assertEqual(time, [Datetime(2000, 1, 1, 0, 15)])
 
-        # meta = view.get_data(mode="meta", **request)["meta"]
-        # self.assertEqual(meta, [""])
+        meta = view.get_data(mode="meta", **request)["meta"]
+        self.assertEqual(meta, [""])
 
-        # data = view.get_data(mode="vals", width=1, height=1, **request)
-        # self.assertEqual(data["values"].tolist(), [[[255]]])
+        data = view.get_data(mode="vals", width=1, height=1, **request)
+        self.assertEqual(data["values"].tolist(), [[[view.fillvalue]]])
+
+    def test_only_gap_no_stop(self):
+        view = self.klass(self.storage1, self.storage6)
+        request = dict(
+            start=Datetime(2000, 1, 1, 0, 15),  # the gap
+        )
+        _requests = view.get_sources_and_requests(mode="meta", **request)
+        self.assertEqual(_requests[0][0]["combine_mode"], "by_bands")
+
+        time = view.get_data(mode="time", **request)["time"]
+        self.assertEqual(time, [Datetime(2000, 1, 1, 0, 15)])
+
+        meta = view.get_data(mode="meta", **request)["meta"]
+        self.assertEqual(meta, [""])
+
+        data = view.get_data(mode="vals", width=1, height=1, **request)
+        self.assertEqual(data["values"].tolist(), [[[view.fillvalue]]])
 
 
 class TestSnap(unittest.TestCase):

--- a/dask_geomodeling/tests/test_raster.py
+++ b/dask_geomodeling/tests/test_raster.py
@@ -848,6 +848,9 @@ class TestGroup(TestCombine, unittest.TestCase):
             origin=Datetime(2000, 1, 1), timedelta=Timedelta(minutes=5), bands=3
         )
         self.storage4 = MockRaster(origin=None)
+        self.storage6 = MockRaster(
+            origin=Datetime(2000, 1, 1, 0, 20), timedelta=Timedelta(minutes=5), bands=1
+        )
 
         self.nodatastorage = MockRaster(
             origin=Datetime(2000, 1, 1),
@@ -1027,6 +1030,60 @@ class TestGroup(TestCombine, unittest.TestCase):
         view = self.klass(storage1, storage2)
         result = view.get_data(**self.vals_request)
         assert_equal(result["values"], 2)
+
+    def test_start_in_gap(self):
+        view = self.klass(self.storage1, self.storage6)
+        request = dict(
+            start=Datetime(2000, 1, 1, 0, 15),  # the gap
+            stop=Datetime(2000, 1, 1, 0, 20),
+        )
+        _requests = view.get_sources_and_requests(mode="meta", **request)
+        self.assertEqual(_requests[0][0]["combine_mode"], "by_bands")
+
+        time = view.get_data(mode="time", **request)["time"]
+        self.assertEqual(time, [Datetime(2000, 1, 1, 0, 15), Datetime(2000, 1, 1, 0, 20)])
+
+        meta = view.get_data(mode="meta", **request)["meta"]
+        self.assertEqual(meta, ["", "Testmeta for band 0"])
+
+        data = view.get_data(mode="vals", width=1, height=1, **request)
+        self.assertEqual(data["values"].tolist(), [[[255]], [[1]]])
+
+    def test_stop_in_gap(self):
+        view = self.klass(self.storage1, self.storage6)
+        request = dict(
+            start=Datetime(2000, 1, 1, 0, 10),
+            stop=Datetime(2000, 1, 1, 0, 15),  # the gap
+        )
+        _requests = view.get_sources_and_requests(mode="meta", **request)
+        self.assertEqual(_requests[0][0]["combine_mode"], "by_bands")
+
+        time = view.get_data(mode="time", **request)["time"]
+        self.assertEqual(time, [Datetime(2000, 1, 1, 0, 10), Datetime(2000, 1, 1, 0, 15)])
+
+        meta = view.get_data(mode="meta", **request)["meta"]
+        self.assertEqual(meta, ["Testmeta for band 2", ""])
+
+        data = view.get_data(mode="vals", width=1, height=1, **request)
+        self.assertEqual(data["values"].tolist(), [[[1]], [[255]]])
+
+    # def test_only_gap(self):
+        # view = self.klass(self.storage1, self.storage6)
+        # request = dict(
+            # start=Datetime(2000, 1, 1, 0, 15),  # the gap
+            # stop=Datetime(2000, 1, 1, 0, 15),  # also the gap
+        # )
+        # _requests = view.get_sources_and_requests(mode="meta", **request)
+        # self.assertEqual(_requests[0][0]["combine_mode"], "by_bands")
+
+        # time = view.get_data(mode="time", **request)["time"]
+        # self.assertEqual(time, [Datetime(2000, 1, 1, 0, 15)])
+
+        # meta = view.get_data(mode="meta", **request)["meta"]
+        # self.assertEqual(meta, [""])
+
+        # data = view.get_data(mode="vals", width=1, height=1, **request)
+        # self.assertEqual(data["values"].tolist(), [[[255]]])
 
 
 class TestSnap(unittest.TestCase):
@@ -1562,7 +1619,7 @@ class TestRasterize(unittest.TestCase):
         properties = [{"id": x, "value": x / 3} for x in (51, 212, 512)]
         self.geometry_source = MockGeometry(squares, properties)
         self.view = raster.Rasterize(self.geometry_source, "id")
-    
+
     def test_attrs(self):
         self.assertFalse(self.view.temporal)
 


### PR DESCRIPTION
When the raster.combine.Group is not fully temporally covered by its sources, there could be inconsistent behaviour in the amount of bands returned, but also incorrect results when using only the `start` parameter to `get_data()` from an not-covered part of the Group (namely, snapping to the nearest source with data instead of returning the NoDataValue). This resulted in IndexErrors when using a Group of Groups (e.g. a Group containing Optimizers, which are Groups too).